### PR TITLE
Add more ignored files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
+# OS X
+.DS_Store
+
+# Xcode
+!default.xcworkspace
+*.xccheckout
+xcuserdata
+profile
+
+# xcodebuild
 build/
+
+# Carthage
+Carthage/Build
+
+# Slather
 slather-report/


### PR DESCRIPTION
This PR adds more files and “folders” that git should ignore. So that we don’t have to depend on users having a global ignore file.

@8W9aG