### PR TITLE
Use xcpretty to format output when building and testing on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 osx_image: xcode7.2
 language: objective-c
+sudo: false
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 osx_image: xcode7.2
 language: objective-c
+env:
+  global:
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
 before_install: 
   - bundle install --without=documentation
 script:
-  - xcodebuild build test -project SPTDataLoader.xcodeproj -scheme SPTDataLoader -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES -enableCodeCoverage YES
+  - set -o pipefail
+  - xcodebuild build test -project SPTDataLoader.xcodeproj -scheme SPTDataLoader -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES -enableCodeCoverage YES | xcpretty -c -f `xcpretty-travis-formatter`;
 after_success: ./slather.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 osx_image: xcode7.2
 language: objective-c
-install: bundle install --without=documentation
+before_install: 
+  - bundle install --without=documentation
 script:
   - xcodebuild build test -project SPTDataLoader.xcodeproj -scheme SPTDataLoader -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES -enableCodeCoverage YES
 after_success: ./slather.sh

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gem 'slather',
   :git      => "https://github.com/viteinfinite/slather",
   :branch   => "feature-profdata"
+gem 'xcpretty'
+gem 'xcpretty-travis-formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     minitest (5.8.3)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
+    rouge (1.10.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -33,12 +34,18 @@ GEM
       activesupport (>= 3)
       claide (~> 0.9.1)
       colored (~> 1.2)
+    xcpretty (0.2.2)
+      rouge (~> 1.8)
+    xcpretty-travis-formatter (0.0.4)
+      xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   slather!
+  xcpretty
+  xcpretty-travis-formatter
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Should result in output which is quite a bit easier to read. The PR also makes sure the correct locale is set.

Also opt-in to not using `sudo` this also opts us in to using the newer Travis-CI architecture.