### PR TITLE
Simplify slather + coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ build/
 
 # Carthage
 Carthage/Build
-
-# Slather
-slather-report/

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,2 +1,5 @@
 coverage_service: coveralls
+ci_service: travis_ci
 xcodeproj: SPTDataLoader.xcodeproj
+source_directory: SPTDataLoader
+ignore: "../**/Developer/*"

--- a/.slather.yml
+++ b/.slather.yml
@@ -2,4 +2,6 @@ coverage_service: coveralls
 ci_service: travis_ci
 xcodeproj: SPTDataLoader.xcodeproj
 source_directory: SPTDataLoader
-ignore: "../**/Developer/*"
+ignore:
+  - "../**/Developer/*"
+  - "SPTDataLoaderTests/*"

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,7 +1,6 @@
 coverage_service: coveralls
 ci_service: travis_ci
 xcodeproj: SPTDataLoader.xcodeproj
-source_directory: SPTDataLoader
 ignore:
   - "../**/Developer/*"
   - "SPTDataLoaderTests/*"

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -4,10 +4,5 @@ set -euo pipefail
 
 bundle exec slather coverage \
     --input-format profdata \
-    --cobertura-xml \
-    --ignore "../**/*/Xcode*" \
-    --output-directory slather-report \
     --scheme SPTDataLoader \
     SPTDataLoader.xcodeproj
-
-bundle exec slather


### PR DESCRIPTION
We were calling slather twice. The second time, ignore wasn't set properly, so system framework coverage data was being posted to coveralls. This PR *should* simplify things. If this works, we can close #11.