### PR TITLE
Move languageHeaderValue to the public API

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequest+Private.h
+++ b/SPTDataLoader/SPTDataLoaderRequest+Private.h
@@ -41,9 +41,4 @@
  */
 @property (nonatomic, weak) id<SPTCancellationToken> cancellationToken;
 
-/**
- * The value to be added to the Accept-Language header by default
- */
-+ (NSString *)languageHeaderValue;
-
 @end

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -108,6 +108,11 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
 + (instancetype)requestWithURL:(NSURL *)URL sourceIdentifier:(NSString *)sourceIdentifier;
 
 /**
+ * The value to be added to the Accept-Language header by default
+ */
++ (NSString *)languageHeaderValue;
+
+/**
  * Adds a header value
  * @param value The value of the header field
  * @param header The header field to add the value to


### PR DESCRIPTION
* We need to get this so our C++ core can append the
same Accept-Language header to our proprietary
transport layer