### PR TITLE
Tweak CocoaDocs output and add a docs badge to readme

### DIFF
--- a/.cocoadocs.yml
+++ b/.cocoadocs.yml
@@ -1,0 +1,9 @@
+highlight-color: '#1db954'
+highlight-dark-color: '#1da74d'
+
+darker-color: '#999999'
+darker-dark-color: '#4c4c4c'
+
+background-color: '#F2F2F2'
+alt-link-color: '#006450'
+warning-color: '#ff6437'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <img alt="SPTDataLoader" src="banner@2x.png" width="100%" max-width="888">
 
-[![Coverage Status](https://coveralls.io/repos/spotify/SPTDataLoader/badge.svg?branch=master&service=github)](https://coveralls.io/github/spotify/SPTDataLoader?branch=master)
 [![Build Status](https://api.travis-ci.org/spotify/SPTDataLoader.svg)](https://travis-ci.org/spotify/SPTDataLoader)
+[![Coverage Status](https://coveralls.io/repos/spotify/SPTDataLoader/badge.svg?branch=master&service=github)](https://coveralls.io/github/spotify/SPTDataLoader?branch=master)
+[![Documentation](https://img.shields.io/cocoapods/metrics/doc-percent/SPTDataLoader.svg)](http://cocoadocs.org/docsets/SPTDataLoader/)
 [![License](https://img.shields.io/github/license/spotify/SPTDataLoader.svg)](LICENSE)
 [![Cocoapods](https://img.shields.io/cocoapods/v/SPTDataLoader.svg)](https://cocoapods.org/?q=SPTDataLoader)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ At Spotify we have begun moving to a decentralised HTTP architecture, and in doi
 
 Thus we came up with a way to elegantly inject tokens in a Just-in-time manner for requests that require them. We also wanted to learn from our mistakes with our proprietary protocol, and bake in back-off policies early to avoid us DDOSing our own backends with huge amounts of eronious requests.
 
+## Documentation :books:
+See the [`SPTDataLoader` documentation](http://cocoadocs.org/docsets/SPTDataLoader) on CocoaDocs.org for the full documentation.
+
+You can also add it to Dash if you want to using the following Dash feed:
+```
+dash-feed://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2FSPTDataLoader%2FSPTDataLoader.xml
+```
+
 ## Contributing :mailbox_with_mail:
 Contributions are welcomed, have a look at the [CONTRIBUTING.md](CONTRIBUTING.md) document for more information.
 


### PR DESCRIPTION
- Add a section on how to find the generated documentation to the readme.
- Add a docs shield to the readme.
- Change the colors of the documentation generated by CocoaDocs be closer to our brand guidelines.