### PR TITLE
Fix incorrect subject in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ At Spotify we have begun moving to a decentralised HTTP architecture, and in doi
 Thus we came up with a way to elegantly inject tokens in a Just-in-time manner for requests that require them. We also wanted to learn from our mistakes with our proprietary protocol, and bake in back-off policies early to avoid us DDOSing our own backends with huge amounts of eronious requests.
 
 ## Documentation :books:
-See the [`SPTDataLoader` documentation](http://cocoadocs.org/docsets/SPTDataLoader) on CocoaDocs.org for the full documentation.
+See the [`SPTDataLoader` documentation](http://cocoadocs.org/docsets/SPTDataLoader) on [CocoaDocs.org](http://cocoadocs.org) for the full documentation.
 
-You can also add it to Dash if you want to using the following Dash feed:
+You can also add it to [Dash](https://kapeli.com/dash) if you want to, using the following Dash feed:
 ```
 dash-feed://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2FSPTDataLoader%2FSPTDataLoader.xml
 ```


### PR DESCRIPTION
- Was missing a comma, making the sentence about the Dash feed hard to read.
- Also linkifies “Dash” and “CocoaDocs.org”.

Whoopsie :stuck_out_tongue_closed_eyes:

@8W9aG @jgavris 