### PR TITLE
Ignore changes in our project.xcconfig file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ project.xcworkspace
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Ignore changes to our project.xcconfig that gets overridden by the build system
+project.xcconfig


### PR DESCRIPTION
* So when our build script changes it, it won't mark
the repo as dirty