### PR TITLE
Delegate challenges to the default handling

### DIFF
--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -280,7 +280,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
         SecTrustRef trust = challenge.protectionSpace.serverTrust;
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:trust]);
     } else {
-        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 }
 

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -384,4 +384,20 @@
     [service cancelAllLoads];
 }
 
+- (void)testDidReceiveChallengeWhenNotAllowingAllCertificatesForwardsResponsiblity
+{
+    NSURLSession *session = [NSURLSession new];
+    NSURLSessionTask *task = [NSURLSessionTask new];
+    NSURLAuthenticationChallenge *challenge = [NSURLAuthenticationChallenge new];
+    __block NSURLSessionAuthChallengeDisposition savedDisposition = NSURLSessionAuthChallengeUseCredential;
+    void(^NSURLSessionCompletionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *) = ^(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential) {
+        savedDisposition = disposition;
+    };
+    [self.service URLSession:session
+                        task:task
+         didReceiveChallenge:challenge
+           completionHandler:NSURLSessionCompletionHandler];
+    XCTAssertEqual(savedDisposition, NSURLSessionAuthChallengePerformDefaultHandling);
+}
+
 @end


### PR DESCRIPTION
* We should not cancel authentication challenges
by default when we do not allow all certificates