### PR TITLE
Add testRetryWithRateLimiter

### DIFF
--- a/SPTDataLoaderTests/NSURLSessionTaskMock.h
+++ b/SPTDataLoaderTests/NSURLSessionTaskMock.h
@@ -24,5 +24,6 @@
 
 @property (nonatomic, assign) NSUInteger numberOfCallsToResume;
 @property (nonatomic, assign) NSUInteger numberOfCallsToCancel;
+@property (nonatomic, strong, readwrite, nullable) dispatch_block_t resumeCallback;
 
 @end

--- a/SPTDataLoaderTests/NSURLSessionTaskMock.m
+++ b/SPTDataLoaderTests/NSURLSessionTaskMock.m
@@ -25,6 +25,9 @@
 - (void)resume
 {
     self.numberOfCallsToResume++;
+    if (self.resumeCallback) {
+        self.resumeCallback();
+    }
 }
 
 - (void)cancel


### PR DESCRIPTION
* Fixes a major bug which allows infinite retries
* Extends the task mock to allow callbacks on resume
calls
* Allows configurable retry queues (other than main)