### PR TITLE
Add testConsumptionObserverTakesIntoAccountResponseHeaders

### DIFF
--- a/SPTDataLoaderTests/NSURLSessionTaskMock.h
+++ b/SPTDataLoaderTests/NSURLSessionTaskMock.h
@@ -25,5 +25,12 @@
 @property (nonatomic, assign) NSUInteger numberOfCallsToResume;
 @property (nonatomic, assign) NSUInteger numberOfCallsToCancel;
 @property (nonatomic, strong, readwrite, nullable) dispatch_block_t resumeCallback;
+@property (nonatomic, strong, readwrite, nullable) NSURLResponse *mockResponse;
+
+#pragma mark NSURLSessionTask
+
+@property (atomic, readonly) int64_t countOfBytesSent;
+@property (atomic, readonly) int64_t countOfBytesReceived;
+@property (atomic, nullable, readonly, copy) NSURLRequest *currentRequest;
 
 @end

--- a/SPTDataLoaderTests/NSURLSessionTaskMock.m
+++ b/SPTDataLoaderTests/NSURLSessionTaskMock.m
@@ -22,6 +22,8 @@
 
 @implementation NSURLSessionTaskMock
 
+#pragma mark NSURLSessionTaskMock
+
 - (void)resume
 {
     self.numberOfCallsToResume++;
@@ -34,5 +36,16 @@
 {
     self.numberOfCallsToCancel++;
 }
+
+- (NSURLResponse *)response
+{
+    return self.mockResponse;
+}
+
+#pragma mark NSURLSessionTask
+
+@synthesize countOfBytesSent;
+@synthesize countOfBytesReceived;
+@synthesize currentRequest;
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.h
@@ -25,5 +25,7 @@
 @interface SPTDataLoaderConsumptionObserverMock : NSObject <SPTDataLoaderConsumptionObserver>
 
 @property (nonatomic, assign) NSInteger numberOfCallsToEndedRequest;
+@property (nonatomic, strong, readwrite, nullable) dispatch_block_t endedRequestCallback;
+@property (nonatomic, assign, readwrite) NSInteger lastBytesDownloaded;
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.m
@@ -27,6 +27,10 @@
                    bytesUploaded:(int)bytesUploaded
 {
     self.numberOfCallsToEndedRequest++;
+    self.lastBytesDownloaded = bytesDownloaded;
+    if (self.endedRequestCallback) {
+        self.endedRequestCallback();
+    }
 }
 
 @end


### PR DESCRIPTION
* Tests asynchronous communication with consumption
observers
* Tests size calculations on the HTTP response
headers
* Makes the mocks more comprehensive