### PR TITLE
Add testErrorDelegateCallbackWhenMismatchInChunkSupport

### DIFF
--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -150,4 +150,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToSuccessfulResponse, 1u, @"The data loader did not relay a successful response to the delegate");
 }
 
+- (void)testErrorDelegateCallbackWhenMismatchInChunkSupport
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    request.chunks = YES;
+    [self.dataLoader performRequest:request];
+    XCTAssertEqual(self.delegate.numberOfCallsToErrorResponse, 1u);
+}
+
 @end

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -28,7 +28,8 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestMethod) {
 };
 
 typedef NS_ENUM(NSInteger, SPTDataLoaderRequestErrorCode) {
-    SPTDataLoaderRequestErrorCodeTimeout
+    SPTDataLoaderRequestErrorCodeTimeout,
+    SPTDataLoaderRequestErrorChunkedRequestWithoutChunkedDelegate
 };
 
 extern NSString * const SPTDataLoaderRequestErrorDomain;


### PR DESCRIPTION
* Test that an error is thrown when the data loader
attempts to load a request that requires chunks but
the delegate does not support chunks
* Removes previous assertion in favor of a less
noisy delegate error callback approach