### PR TITLE
Implement -debugDescription for Request and Response

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -171,6 +171,11 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
     return languageHeaderValue;
 }
 
+- (NSString *)debugDescription
+{
+    return [NSString stringWithFormat:@"%@ { URL: %@ }", [super debugDescription], self.URL];
+}
+
 #pragma mark NSCopying
 
 - (id)copyWithZone:(NSZone *)zone

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -183,7 +183,7 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 - (NSString *)debugDescription
 {
-    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %lu, headers: %@ }", [super debugDescription], self.response.URL, self.statusCode, self.responseHeaders];
+    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %lu, headers: %@ }", [super debugDescription], self.response.URL, (long)self.statusCode, self.responseHeaders];
 }
 
 

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -183,7 +183,7 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 - (NSString *)debugDescription
 {
-    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %lu, headers: %@ }", [super debugDescription], self.response.URL, (long)self.statusCode, self.responseHeaders];
+    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %ld, headers: %@ }", [super debugDescription], self.response.URL, (long)self.statusCode, self.responseHeaders];
 }
 
 

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -181,4 +181,10 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
     return [httpDateFormatter dateFromString:retryAfterValue];
 }
 
+- (NSString *)debugDescription
+{
+    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %lu, headers: %@ }", [super debugDescription], self.response.URL, self.statusCode, self.responseHeaders];
+}
+
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -161,4 +161,14 @@
     XCTAssertEqualObjects(@"fr-CA, pt-PT;q=0.50, en;q=0.01", languageValues);
 }
 
+- (void)testDebugDescription
+{
+    XCTAssertNotNil(self.request.debugDescription,
+                    @"The debugDescription shouldn't be nil.");
+    
+    NSString *URLString = [NSString stringWithFormat:@"URL: %@", self.URL.absoluteString];
+    XCTAssertTrue([self.request.debugDescription containsString:URLString],
+                  @"The debugDescription should contain the URL of the request.");
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
@@ -193,7 +193,7 @@
     XCTAssertTrue([self.response.debugDescription containsString:URLString],
                   @"The debugDescription should contain the URL of the response");
     
-    NSString *statusCodeString = [NSString stringWithFormat:@"status code: %lu", (long)self.response.statusCode];
+    NSString *statusCodeString = [NSString stringWithFormat:@"status code: %ld", (long)self.response.statusCode];
     XCTAssertTrue([self.response.debugDescription containsString:statusCodeString],
                   @"The debugDescription should contain the status code of the response");
     

--- a/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
@@ -184,4 +184,23 @@
     XCTAssertFalse(shouldRetry, @"The response should not retry when the connection was cancelled");
 }
 
+- (void)testDebugDescription
+{
+    XCTAssertNotNil(self.response.debugDescription,
+                    @"The debugDescription shouldn't be nil.");
+    
+    NSString *URLString = [NSString stringWithFormat:@"URL: %@", self.urlResponse.URL];
+    XCTAssertTrue([self.response.debugDescription containsString:URLString],
+                  @"The debugDescription should contain the URL of the response");
+    
+    NSString *statusCodeString = [NSString stringWithFormat:@"status code: %lu", (long)self.response.statusCode];
+    XCTAssertTrue([self.response.debugDescription containsString:statusCodeString],
+                  @"The debugDescription should contain the status code of the response");
+    
+    NSString *headersString = [NSString stringWithFormat:@"headers: %@", self.response.responseHeaders];
+    XCTAssertTrue([self.response.debugDescription containsString:headersString],
+                  @"The debugDescription should contain the headers code of the response");
+}
+
+
 @end


### PR DESCRIPTION
Implement `-debugDescription` methods for `SPTDataLoaderRequest` and `SPTDataLoaderResponse`. 

Format of the output is the same as `NSURLResponse` and `NSURLRequest`.