### PR TITLE
Add nullability & generic type annotations to all classes

### DIFF
--- a/SPTDataLoader/NSDictionary+HeaderSize.h
+++ b/SPTDataLoader/NSDictionary+HeaderSize.h
@@ -20,6 +20,8 @@
  */
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A category for calculating the size of a header represented by an NSDictionary
  */
@@ -31,3 +33,5 @@
 @property (nonatomic, assign, readonly, getter = spt_byteSizeOfHeaders) NSInteger byteSizeOfHeaders;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/NSDictionary+HeaderSize.m
+++ b/SPTDataLoader/NSDictionary+HeaderSize.m
@@ -20,6 +20,8 @@
  */
 #import "NSDictionary+HeaderSize.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation NSDictionary (HeaderSize)
 
 - (NSInteger)spt_byteSizeOfHeaders
@@ -45,3 +47,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoader+Private.h
+++ b/SPTDataLoader/SPTDataLoader+Private.h
@@ -22,6 +22,8 @@
 
 #import "SPTDataLoaderRequestResponseHandler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The private API for the data loader for internal use in the SPTDataLoader library
  */
@@ -34,3 +36,5 @@
 + (instancetype)dataLoaderWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -26,10 +26,12 @@
 #import "SPTDataLoaderDelegate.h"
 #import "SPTDataLoaderResponse+Private.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPTDataLoader ()
 
-@property (nonatomic, strong) NSHashTable *cancellationTokens;
-@property (nonatomic, strong) NSMutableArray *requests;
+@property (nonatomic, strong) NSHashTable<id<SPTDataLoaderCancellationToken>> *cancellationTokens;
+@property (nonatomic, strong) NSMutableArray<SPTDataLoaderRequest *> *requests;
 
 @end
 
@@ -182,3 +184,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
@@ -22,9 +22,13 @@
 
 #import "SPTDataLoaderCancellationTokenFactory.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The generic implementation for the cancellation token factory
  */
 @interface SPTDataLoaderCancellationTokenFactoryImplementation : NSObject <SPTDataLoaderCancellationTokenFactory>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
@@ -22,6 +22,8 @@
 
 #import "SPTDataLoaderCancellationTokenImplementation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation SPTDataLoaderCancellationTokenFactoryImplementation
 
 #pragma mark SPTDataLoaderCancellationTokenFactory
@@ -34,3 +36,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
@@ -22,6 +22,8 @@
 
 #import "SPTDataLoaderCancellationToken.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The implementation for the cancellation token API
  */
@@ -33,6 +35,8 @@
  * @param cancelObject The object that will be cancelled
  */
 + (instancetype)cancellationTokenImplementationWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate
-                                               cancelObject:(id)cancelObject;
+                                               cancelObject:(nullable id)cancelObject;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
@@ -20,10 +20,12 @@
  */
 #import "SPTDataLoaderCancellationTokenImplementation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPTDataLoaderCancellationTokenImplementation ()
 
+
 @property (nonatomic, assign, readwrite, getter = isCancelled) BOOL cancelled;
-@property (nonatomic, weak, readwrite) id<SPTDataLoaderCancellationTokenDelegate> delegate;
 
 @end
 
@@ -32,12 +34,12 @@
 #pragma mark SPTDataLoaderCancellationTokenImplementation
 
 + (instancetype)cancellationTokenImplementationWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate
-                                               cancelObject:(id)cancelObject
+                                               cancelObject:(nullable id)cancelObject
 {
     return [[self alloc] initWithDelegate:delegate cancelObject:cancelObject];
 }
 
-- (instancetype)initWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate cancelObject:(id)cancelObject
+- (instancetype)initWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate cancelObject:(nullable id)cancelObject
 {
     if (!(self = [super init])) {
         return nil;
@@ -67,3 +69,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderFactory+Private.h
+++ b/SPTDataLoader/SPTDataLoaderFactory+Private.h
@@ -25,6 +25,8 @@
 @protocol SPTDataLoaderRequestResponseHandlerDelegate;
 @protocol SPTDataLoaderAuthoriser;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The private API for the data loader factory for internal use in the SPTDataLoader library
  */
@@ -35,7 +37,9 @@
  * @param requestResponseHandlerDelegate The private delegate to delegate request handling to
  * @param authorisers An NSArray of SPTDataLoaderAuthoriser objects for supporting different forms of authorisation
  */
-+ (instancetype)dataLoaderFactoryWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
-                                                        authorisers:(NSArray *)authorisers;
++ (instancetype)dataLoaderFactoryWithRequestResponseHandlerDelegate:(nullable id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
+                                                        authorisers:(nullable NSArray<id<SPTDataLoaderAuthoriser>> *)authorisers;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -28,9 +28,11 @@
 #import "SPTDataLoaderResponse+Private.h"
 #import "SPTDataLoaderRequest+Private.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPTDataLoaderFactory () <SPTDataLoaderRequestResponseHandlerDelegate, SPTDataLoaderAuthoriserDelegate>
 
-@property (nonatomic, strong) NSMapTable *requestToRequestResponseHandler;
+@property (nonatomic, strong) NSMapTable<SPTDataLoaderRequest *, id<SPTDataLoaderRequestResponseHandler>> *requestToRequestResponseHandler;
 @property (nonatomic, strong, readwrite) dispatch_queue_t requestTimeoutQueue;
 
 @end
@@ -39,14 +41,14 @@
 
 #pragma mark Private
 
-+ (instancetype)dataLoaderFactoryWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
-                                                        authorisers:(NSArray *)authorisers
++ (instancetype)dataLoaderFactoryWithRequestResponseHandlerDelegate:(nullable id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
+                                                        authorisers:(nullable NSArray<id<SPTDataLoaderAuthoriser>> *)authorisers
 {
     return [[self alloc] initWithRequestResponseHandlerDelegate:requestResponseHandlerDelegate authorisers:authorisers];
 }
 
-- (instancetype)initWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
-                                           authorisers:(NSArray *)authorisers
+- (instancetype)initWithRequestResponseHandlerDelegate:(nullable id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
+                                           authorisers:(nullable NSArray<id<SPTDataLoaderAuthoriser>> *)authorisers
 {
     if (!(self = [super init])) {
         return nil;
@@ -161,8 +163,8 @@
 
 #pragma mark SPTDataLoaderRequestResponseHandlerDelegate
 
-- (id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                              performRequest:(SPTDataLoaderRequest *)request
+- (nullable id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                                                       performRequest:(SPTDataLoaderRequest *)request
 {
     if (self.offline) {
         request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
@@ -216,3 +218,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRateLimiter.m
+++ b/SPTDataLoader/SPTDataLoaderRateLimiter.m
@@ -22,13 +22,15 @@
 
 #import "SPTDataLoaderRequest.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPTDataLoaderRateLimiter ()
 
 @property (nonatomic, assign) double requestsPerSecond;
 
-@property (nonatomic, strong) NSMutableDictionary *serviceEndpointRequestsPerSecond;
-@property (nonatomic, strong) NSMutableDictionary *serviceEndpointLastExecution;
-@property (nonatomic, strong) NSMutableDictionary *serviceEndpointRetryAt;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *serviceEndpointRequestsPerSecond;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *serviceEndpointLastExecution;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *serviceEndpointRetryAt;
 
 @end
 
@@ -147,3 +149,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequest+Private.h
+++ b/SPTDataLoader/SPTDataLoaderRequest+Private.h
@@ -22,6 +22,8 @@
 
 @protocol SPTDataLoaderCancellationToken;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A private delegate API for the objects in the SPTDataLoader library to use
  */
@@ -42,3 +44,5 @@
 @property (nonatomic, weak) id<SPTDataLoaderCancellationToken> cancellationToken;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -22,6 +22,8 @@
 
 #import "SPTDataLoaderRequest+Private.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSString * const SPTDataLoaderRequestErrorDomain = @"com.spotify.dataloader.request";
 
 static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMethod requestMethod);
@@ -30,7 +32,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
 
 @property (nonatomic, assign, readwrite) int64_t uniqueIdentifier;
 
-@property (nonatomic, strong) NSMutableDictionary *mutableHeaders;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *mutableHeaders;
 @property (nonatomic, assign) BOOL retriedAuthorisation;
 @property (nonatomic, weak) id<SPTDataLoaderCancellationToken> cancellationToken;
 
@@ -40,12 +42,12 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
 
 #pragma mark SPTDataLoaderRequest
 
-+ (instancetype)requestWithURL:(NSURL *)URL sourceIdentifier:(NSString *)sourceIdentifier
++ (instancetype)requestWithURL:(NSURL *)URL sourceIdentifier:(nullable NSString *)sourceIdentifier
 {
     return [[self alloc] initWithURL:URL sourceIdentifier:sourceIdentifier];
 }
 
-- (instancetype)initWithURL:(NSURL *)URL sourceIdentifier:(NSString *)sourceIdentifier
+- (instancetype)initWithURL:(NSURL *)URL sourceIdentifier:(nullable NSString *)sourceIdentifier
 {
     static int64_t uniqueIdentifierBarrier = 0;
 
@@ -183,7 +185,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
 
 #pragma mark NSCopying
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(nullable NSZone *)zone
 {
     __typeof(self) copy = [self.class requestWithURL:self.URL sourceIdentifier:self.sourceIdentifier];
     copy.maximumRetryCount = self.maximumRetryCount;
@@ -218,3 +220,5 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
         case SPTDataLoaderRequestMethodPut: return SPTDataLoaderRequestPutMethodString;
     }
 }
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -26,6 +26,8 @@
 @protocol SPTDataLoaderCancellationToken;
 @protocol SPTDataLoaderRequestResponseHandler;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A private delegate API for the creator of SPTDataLoader to use for routing requests through a user authentication
  * layer
@@ -37,8 +39,8 @@
  * @param requestResponseHandler The object that can perform requests and responses
  * @param request The object describing the request to perform
  */
-- (id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                              performRequest:(SPTDataLoaderRequest *)request;
+- (nullable id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                                                       performRequest:(SPTDataLoaderRequest *)request;
 
 @optional
 
@@ -66,7 +68,7 @@
 /**
  * The object to delegate performing requests to
  */
-@property (nonatomic, weak, readonly) id<SPTDataLoaderRequestResponseHandlerDelegate> requestResponseHandlerDelegate;
+@property (nonatomic, weak, readonly, nullable) id<SPTDataLoaderRequestResponseHandlerDelegate> requestResponseHandlerDelegate;
 
 /**
  * Call when a response successfully completed
@@ -109,3 +111,5 @@
 - (void)authoriseRequest:(SPTDataLoaderRequest *)request;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -25,6 +25,8 @@
 @class SPTDataLoaderResponse;
 @protocol SPTDataLoaderRequestResponseHandler;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The handler for performing a URL session task and forwarding the requests to relevant request response handler
  */
@@ -65,7 +67,7 @@
  * Tell the operation the URL session has completed the request
  * @param error An optional error to use if the request was not completed successfully
  */
-- (SPTDataLoaderResponse *)completeWithError:(NSError *)error;
+- (SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error;
 /**
  * Gets called whenever the original request was redirected.
  * Returns YES to allow redirect, NO to block it.
@@ -77,3 +79,5 @@
 - (void)start;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -29,6 +29,8 @@
 
 #import "SPTDataLoaderExponentialTimer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 
 @interface SPTDataLoaderRequestTaskHandler ()
@@ -37,7 +39,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 @property (nonatomic, strong) SPTDataLoaderRateLimiter *rateLimiter;
 
 @property (nonatomic, strong) SPTDataLoaderResponse *response;
-@property (nonatomic, strong) NSMutableData *receivedData;
+@property (nonatomic, strong, nullable) NSMutableData *receivedData;
 @property (nonatomic, assign) CFAbsoluteTime absoluteStartTime;
 @property (nonatomic, assign) NSUInteger retryCount;
 @property (nonatomic, assign) NSUInteger waitCount;
@@ -110,7 +112,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
     }];
 }
 
-- (SPTDataLoaderResponse *)completeWithError:(NSError *)error
+- (SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error
 {
     id<SPTDataLoaderRequestResponseHandler> requestResponseHandler = self.requestResponseHandler;
     if (!self.response) {
@@ -238,3 +240,5 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderResolver.m
+++ b/SPTDataLoader/SPTDataLoaderResolver.m
@@ -24,8 +24,8 @@
 
 @interface SPTDataLoaderResolver ()
 
-@property (nonatomic, strong) NSMutableDictionary *resolverHost;
-@property (nonatomic, strong) NSHashTable *addresses;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSArray<SPTDataLoaderResolverAddress *> *> *resolverHost;
+@property (nonatomic, strong) NSHashTable<SPTDataLoaderResolverAddress *> *addresses;
 
 @end
 
@@ -45,7 +45,7 @@
     return host;
 }
 
-- (void)setAddresses:(NSArray *)addresses forHost:(NSString *)host
+- (void)setAddresses:(NSArray<NSString *> *)addresses forHost:(NSString *)host
 {
     NSMutableArray *mutableAddress = [NSMutableArray new];
     for (NSString *address in addresses) {

--- a/SPTDataLoader/SPTDataLoaderResolverAddress.h
+++ b/SPTDataLoader/SPTDataLoaderResolverAddress.h
@@ -20,6 +20,8 @@
  */
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * An object for tracking a resolver addresses reachability
  */
@@ -46,3 +48,5 @@
 - (void)failedToReach;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderResolverAddress.m
+++ b/SPTDataLoader/SPTDataLoaderResolverAddress.m
@@ -20,6 +20,8 @@
  */
 #import "SPTDataLoaderResolverAddress.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPTDataLoaderResolverAddress ()
 
 @property (nonatomic, assign) NSTimeInterval stalePeriod;
@@ -69,3 +71,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderResponse+Private.h
+++ b/SPTDataLoader/SPTDataLoaderResponse+Private.h
@@ -22,6 +22,8 @@
 
 @class SPTDataLoaderRequest;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A private delegate API for the objects in the SPTDataLoader library to use
  */
@@ -30,11 +32,11 @@
 /**
  * The error that the request generated
  */
-@property (nonatomic, strong, readwrite) NSError *error;
+@property (nonatomic, strong, readwrite, nullable) NSError *error;
 /**
  * Allows private consumers to alter the data for the response
  */
-@property (nonatomic, strong, readwrite) NSData *body;
+@property (nonatomic, strong, readwrite, nullable) NSData *body;
 /**
  * Allows private consumers to alter the request time for the response
  */
@@ -45,7 +47,7 @@
  * @param request The request object making up the response
  * @param response The URL response received from the session
  */
-+ (instancetype)dataLoaderResponseWithRequest:(SPTDataLoaderRequest *)request response:(NSURLResponse *)response;
++ (instancetype)dataLoaderResponseWithRequest:(SPTDataLoaderRequest *)request response:(nullable NSURLResponse *)response;
 
 /**
  * Whether we should retry the current request based on the current response data
@@ -53,3 +55,5 @@
 - (BOOL)shouldRetry;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -22,14 +22,16 @@
 
 #import "SPTDataLoaderResponse+Private.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSString * const SPTDataLoaderResponseErrorDomain = @"com.sptdataloaderresponse.error";
 
 static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 @interface SPTDataLoaderResponse ()
 
-@property (nonatomic, strong, readonly) NSURLResponse *response;
-@property (nonatomic, strong, readwrite) NSDictionary *responseHeaders;
+@property (nonatomic, strong, readonly, nullable) NSURLResponse *response;
+@property (nonatomic, strong, readwrite) NSDictionary<NSString *, NSString *> *responseHeaders;
 @property (nonatomic, strong, readwrite) NSError *error;
 @property (nonatomic, strong, readwrite) NSData *body;
 @property (nonatomic, assign, readwrite) NSTimeInterval requestTime;
@@ -40,12 +42,12 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 #pragma mark Private
 
-+ (instancetype)dataLoaderResponseWithRequest:(SPTDataLoaderRequest *)request response:(NSURLResponse *)response
++ (instancetype)dataLoaderResponseWithRequest:(SPTDataLoaderRequest *)request response:(nullable NSURLResponse *)response
 {
     return [[self alloc] initWithRequest:request response:response];
 }
 
-- (instancetype)initWithRequest:(SPTDataLoaderRequest *)request response:(NSURLResponse *)response
+- (instancetype)initWithRequest:(SPTDataLoaderRequest *)request response:(nullable NSURLResponse *)response
 {
     if (!(self = [super init])) {
         return nil;
@@ -163,7 +165,7 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
     return NO;
 }
 
-- (NSDate *)retryAfterForHeaders:(NSDictionary *)headers
+- (nullable NSDate *)retryAfterForHeaders:(NSDictionary<NSString *, NSString *> *)headers
 {
     static NSDateFormatter *httpDateFormatter;
     static dispatch_once_t onceToken;
@@ -188,3 +190,5 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
@@ -113,7 +113,7 @@
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     [self.factory requestResponseHandler:requestResponseHandler performRequest:request];
     SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
-    [self.factory receivedDataChunk:nil forResponse:response];
+    [self.factory receivedDataChunk:[NSData new] forResponse:response];
     XCTAssertEqual(requestResponseHandler.numberOfReceivedDataRequestCalls, 1u, @"The factory did not relay a received data chunk response to the correct handler");
 }
 
@@ -165,21 +165,27 @@
 - (void)testRelayToDelegateWhenPerformingRequest
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.factory requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     XCTAssertEqual(request, self.delegate.lastRequestPerformed, @"The factory did not relay the perform request to it's delegate");
 }
 
 - (void)testRelayAuthorisingSuccessToDelegate
 {
+    SPTDataLoaderAuthoriserMock *authoriser = [SPTDataLoaderAuthoriserMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    [self.factory dataLoaderAuthoriser:nil authorisedRequest:request];
+    [self.factory dataLoaderAuthoriser:authoriser authorisedRequest:request];
     XCTAssertEqual(request, self.delegate.lastRequestAuthorised, @"The factory did not relay the request authorisation success to it's delegate");
 }
 
 - (void)testRelayAuthorisationFailureToDelegate
 {
+    SPTDataLoaderAuthoriserMock *authoriser = [SPTDataLoaderAuthoriserMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    [self.factory dataLoaderAuthoriser:nil didFailToAuthoriseRequest:request withError:nil];
+    NSError *error = [NSError new];
+    [self.factory dataLoaderAuthoriser:authoriser didFailToAuthoriseRequest:request withError:error];
     XCTAssertEqual(request, self.delegate.lastRequestFailed, @"The factory did not relay the request authorisation failure to it's delegate");
 }
 

--- a/SPTDataLoaderTests/SPTDataLoaderRateLimiterTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRateLimiterTest.m
@@ -79,8 +79,11 @@
 
 - (void)testExecutedRequestWithNilRequest
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     // Test no crash
     [self.rateLimiter executedRequest:nil];
+#pragma clang diagnostic pop
 }
 
 - (void)testRequestsPerSecondDefault
@@ -101,8 +104,11 @@
 
 - (void)testSetRetryAfterWithNilURL
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     // Test no crash
     [self.rateLimiter setRetryAfter:60.0 forURL:nil];
+#pragma clang diagnostic pop
 }
 
 - (void)testResetRetryAfterAfterSuccessfulExecution

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
@@ -58,7 +58,7 @@
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.requestResponseHandler = [SPTDataLoaderRequestResponseHandlerMock new];
     self.rateLimiter = [SPTDataLoaderRateLimiter rateLimiterWithDefaultRequestsPerSecond:10.0];
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"]
                                        sourceIdentifier:nil];
     self.task = [NSURLSessionTaskMock new];
     self.handler = [SPTDataLoaderRequestTaskHandler dataLoaderRequestTaskHandlerWithTask:self.task
@@ -97,7 +97,7 @@
 - (void)testRelayFailedResponse
 {
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
-    [self.handler receiveResponse:nil];
+    [self.handler receiveResponse:[NSURLResponse new]];
     [self.handler completeWithError:error];
     XCTAssertEqual(self.requestResponseHandler.numberOfFailedResponseCalls, 1u, @"The handler did not relay the failed response onto its request response handler");
 }
@@ -154,18 +154,18 @@
 {
     NSString *dataString = @"TEST";
     NSData *data = [dataString dataUsingEncoding:NSUTF8StringEncoding];
-    [self.handler receiveResponse:nil];
+    [self.handler receiveResponse:[NSURLResponse new]];
     [self.handler receiveData:data];
     [self.handler receiveData:data];
     SPTDataLoaderResponse *response = [self.handler completeWithError:nil];
-    NSString *receivedString = [[NSString alloc] initWithData:response.body encoding:NSUTF8StringEncoding];
+    NSString *receivedString = [[NSString alloc] initWithData:(NSData * _Nonnull)response.body encoding:NSUTF8StringEncoding];
     XCTAssertEqualObjects([dataString stringByAppendingString:dataString], receivedString);
 }
 
 - (void)testCancelledError
 {
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil];
-    [self.handler receiveResponse:nil];
+    [self.handler receiveResponse:[NSURLResponse new]];
     [self.handler completeWithError:error];
     XCTAssertEqual(self.requestResponseHandler.numberOfCancelledRequestCalls, 1u, @"The handler did not relay the failed response onto its request response handler");
 }
@@ -178,7 +178,7 @@
     self.task.resumeCallback = ^ {
         __strong __typeof(self) strongSelf = weakSelf;
         NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
-        [strongSelf.handler receiveResponse:nil];
+        [strongSelf.handler receiveResponse:[NSURLResponse new]];
         [strongSelf.handler completeWithError:error];
         if (strongSelf.request.maximumRetryCount - 1 == strongSelf.task.numberOfCallsToResume) {
             [expectation fulfill];

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -73,14 +73,20 @@
 
 - (void)testAddValueToNilHeader
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.request addValue:@"Value" forHeader:nil];
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(self.request.headers, @{}, @"The headers should not reflect an added value with an empty header");
 }
 
 - (void)testAddNilValueToHeader
 {
     [self.request addValue:@"Value" forHeader:@"Header"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.request addValue:nil forHeader:@"Header"];
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(self.request.headers, @{}, @"The headers should remove a header when added with an empty value");
 }
 

--- a/SPTDataLoaderTests/SPTDataLoaderResolverTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResolverTest.m
@@ -55,7 +55,7 @@
 - (void)testDefaultToHostIfNoOverridingAddress
 {
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
-    NSString *address = [self.resolver addressForHost:URL.host];
+    NSString *address = [self.resolver addressForHost:(NSString * _Nonnull)URL.host];
     XCTAssertEqualObjects(URL.host, address, @"The address should be identical to the URL host if no overrides are supplied");
 }
 
@@ -63,8 +63,8 @@
 {
     NSString *overrideAddresss = @"192.168.0.1";
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
-    [self.resolver setAddresses:@[ overrideAddresss ] forHost:URL.host];
-    NSString *host = [self.resolver addressForHost:URL.host];
+    [self.resolver setAddresses:@[ overrideAddresss ] forHost:(NSString * _Nonnull)URL.host];
+    NSString *host = [self.resolver addressForHost:(NSString * _Nonnull)URL.host];
     XCTAssertEqualObjects(host, overrideAddresss, @"The address should be overridden");
 }
 
@@ -72,9 +72,9 @@
 {
     NSString *overrideAddresss = @"192.168.0.1";
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
-    [self.resolver setAddresses:@[ overrideAddresss ] forHost:URL.host];
+    [self.resolver setAddresses:@[ overrideAddresss ] forHost:(NSString * _Nonnull)URL.host];
     [self.resolver markAddressAsUnreachable:overrideAddresss];
-    NSString *host = [self.resolver addressForHost:URL.host];
+    NSString *host = [self.resolver addressForHost:(NSString * _Nonnull)URL.host];
     XCTAssertEqualObjects(host, URL.host, @"The address should not be overridden if unreachable");
 }
 

--- a/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
@@ -42,7 +42,7 @@
 {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeOK
@@ -72,7 +72,7 @@
 
 - (void)testShouldRetryWithNotFoundHTTPStatusCode
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeNotFound
@@ -105,7 +105,7 @@
 
 - (void)testShouldRetryDefault
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:self.request response:nil];
     BOOL shouldRetry = [self.response shouldRetry];
@@ -119,7 +119,7 @@
 
 - (void)testErrorForHTTPStatusCodeNotFound
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeNotFound
@@ -138,7 +138,7 @@
 
 - (void)testRelativeRetryAfter
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"] sourceIdentifier:nil];
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"] sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeNotFound
                                                   HTTPVersion:@"1.1"
@@ -150,7 +150,7 @@
 
 - (void)testAbsoluteRetryAfter
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeNotFound
@@ -163,7 +163,7 @@
 
 - (void)testShouldNotRetryWithInvalidHTTPStatusCode
 {
-    self.request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
+    self.request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"]
                                        sourceIdentifier:nil];
     self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                    statusCode:SPTDataLoaderResponseHTTPStatusCodeInvalid

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -107,7 +107,10 @@
 {
     // Test no crash occurs
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     
     NSURLSessionDataTask *dataTask = self.session.lastDataTask;
     [self.service URLSession:self.session
@@ -120,9 +123,12 @@
 {
     [self.resolver setAddresses:@[ @"192.168.0.1" ] forHost:@"spclient.wg.spotify.com"];
     
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"]
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"]
                                                         sourceIdentifier:nil];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     XCTAssertEqualObjects(request.URL.absoluteString, @"https://192.168.0.1/thing");
 }
 
@@ -131,21 +137,26 @@
     SPTDataLoaderAuthoriserMock *authoriserMock = [SPTDataLoaderAuthoriserMock new];
     SPTDataLoaderFactory<SPTDataLoaderRequestResponseHandler> *factory = (SPTDataLoaderFactory<SPTDataLoaderRequestResponseHandler> *)[self.service createDataLoaderFactoryWithAuthorisers:@[ authoriserMock ]];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
     [self.service requestResponseHandler:factory performRequest:request];
     XCTAssertEqual(authoriserMock.numberOfCallsToAuthoriseRequest, 1u, @"The service did not check the requests authorisation");
 }
 
 - (void)testRequestAuthorised
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     // Test no crash occurs on optional delegate method
     [self.service requestResponseHandler:nil authorisedRequest:nil];
+#pragma clang diagnostic pop
 }
 
 - (void)testRequestAuthorisationFailed
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    [self.service requestResponseHandler:requestResponseHandlerMock failedToAuthoriseRequest:request error:nil];
+    NSError *error = [NSError new];
+    [self.service requestResponseHandler:requestResponseHandlerMock failedToAuthoriseRequest:request error:error];
     XCTAssertEqual(requestResponseHandlerMock.numberOfFailedResponseCalls, 1u, @"The service did not call a failed response on a failed authorisation attempt");
 }
 
@@ -153,6 +164,7 @@
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
     id<SPTDataLoaderCancellationToken> cancellationToken = [self.service requestResponseHandler:requestResponseHandlerMock
                                                                                  performRequest:request];
     [cancellationToken cancel];
@@ -162,7 +174,10 @@
 - (void)testSessionDidReceiveResponse
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     
     NSURLSessionDataTask *dataTask = self.session.lastDataTask;
     __block BOOL calledCompletionHandler = NO;
@@ -175,9 +190,12 @@
 
 - (void)testRedirectionCallbackAbortsTooManyRedirects
 {
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://localhost"]
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://localhost"]
                                                         sourceIdentifier:@"-"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     NSURLSessionTask *task = ((SPTDataLoaderRequestTaskHandler *)[self.service.handlers lastObject]).task;
 
     NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:request.URL
@@ -219,9 +237,12 @@
 
 - (void)testRedirectionCallbackDoesNotAbortAfterFewRedirects
 {
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:[NSURL URLWithString:@"https://localhost"]
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:(NSURL * _Nonnull)[NSURL URLWithString:@"https://localhost"]
                                                         sourceIdentifier:@"-"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     NSURLSessionTask *task = ((SPTDataLoaderRequestTaskHandler *)[self.service.handlers lastObject]).task;
 
     NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:request.URL
@@ -268,6 +289,7 @@
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     request.chunks = YES;
+    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
     [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
     NSData *data = [@"thing" dataUsingEncoding:NSUTF8StringEncoding];
     [self.service URLSession:self.service.session dataTask:self.session.lastDataTask didReceiveData:data];
@@ -278,6 +300,7 @@
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
     [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
     [self.service URLSession:self.session task:self.session.lastDataTask didCompleteWithError:nil];
     XCTAssertEqual(requestResponseHandlerMock.numberOfSuccessfulDataResponseCalls, 1u, @"The service did not call successfully received response on the request response handler");
@@ -288,7 +311,10 @@
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     request.skipNSURLCache = NO;
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     NSCachedURLResponse *dummyResponse = [NSCachedURLResponse new];
     
     __block NSCachedURLResponse *blockResponse = nil;
@@ -303,8 +329,12 @@
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     request.skipNSURLCache = YES;
+    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     NSCachedURLResponse *dummyResponse = [NSCachedURLResponse new];
     
     __block NSCachedURLResponse *blockResponse = nil;
@@ -439,7 +469,10 @@
     NSURL *URL = [NSURL URLWithString:@"https://localhost"];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL
                                                         sourceIdentifier:@"-"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [self.service requestResponseHandler:nil performRequest:request];
+#pragma clang diagnostic pop
     NSURLSessionTask *task = ((SPTDataLoaderRequestTaskHandler *)[self.service.handlers lastObject]).task;
 
     [self.resolver setAddresses:@[ @"newhost" ] forHost:@"localhost"];
@@ -458,7 +491,7 @@
                   newRequest:urlRequest
            completionHandler:^(NSURLRequest *newURLRequest) {
                calledCompletionHandler = YES;
-               XCTAssertEqualObjects(newURLRequest.URL.host, [self.resolver addressForHost:URL.host]);
+               XCTAssertEqualObjects(newURLRequest.URL.host, [self.resolver addressForHost:(NSString * _Nonnull)URL.host]);
                XCTAssertEqualObjects(urlRequest.allHTTPHeaderFields, newURLRequest.allHTTPHeaderFields);
            }];
 

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -123,7 +123,7 @@
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     request.chunks = YES;
     SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
-    [self.dataLoader receivedDataChunk:nil forResponse:response];
+    [self.dataLoader receivedDataChunk:[NSData new] forResponse:response];
     XCTAssertEqual(self.delegate.numberOfCallsToReceiveDataChunk, 1u, @"The data loader did not relay a received data chunk response to the delegate");
 }
 

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -36,6 +36,8 @@ FOUNDATION_EXPORT double SPTDataLoaderVersionNumber;
 FOUNDATION_EXPORT const unsigned char SPTDataLoaderVersionString[];
 #endif // SPT_BUILDING_FRAMEWORK
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The object used for performing requests
  */
@@ -44,7 +46,7 @@ FOUNDATION_EXPORT const unsigned char SPTDataLoaderVersionString[];
 /**
  * The object listening to the data loader
  */
-@property (nonatomic, weak) id<SPTDataLoaderDelegate> delegate;
+@property (nonatomic, weak, nullable) id<SPTDataLoaderDelegate> delegate;
 /**
  * The queue to call the delegate selectors on
  * @discussion By default this is the main queue
@@ -62,3 +64,5 @@ FOUNDATION_EXPORT const unsigned char SPTDataLoaderVersionString[];
 - (void)cancelAllLoads;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
+++ b/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
@@ -24,6 +24,8 @@
 
 @protocol SPTDataLoaderAuthoriser;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol SPTDataLoaderAuthoriserDelegate <NSObject>
 
 /**
@@ -58,7 +60,7 @@
 /**
  * The object listening to the authoriser
  */
-@property (nonatomic, weak) id<SPTDataLoaderAuthoriserDelegate> delegate;
+@property (nonatomic, weak, nullable) id<SPTDataLoaderAuthoriserDelegate> delegate;
 
 /**
  * Whether a request requires authorisation from this authoriser
@@ -84,3 +86,5 @@
 - (void)refresh;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
+++ b/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
@@ -22,6 +22,8 @@
 
 @protocol SPTDataLoaderCancellationToken;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The protocol an object listening to the cancellation token must conform to
  */
@@ -48,11 +50,11 @@
  * The object listening to the cancellation token
  * @discussion This is immutable, the cancellation token should be fed this on its creation
  */
-@property (nonatomic, weak, readonly) id<SPTDataLoaderCancellationTokenDelegate> delegate;
+@property (nonatomic, weak, readonly, nullable) id<SPTDataLoaderCancellationTokenDelegate> delegate;
 /**
  * The object that will be affected by the cancellation
  */
-@property (nonatomic, strong, readonly) id objectToCancel;
+@property (nonatomic, strong, readonly, nullable) id objectToCancel;
 
 /**
  * Cancels the cancellation token
@@ -60,3 +62,5 @@
 - (void)cancel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
+++ b/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
@@ -22,6 +22,8 @@
 
 @class SPTDataLoaderResponse;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The protocol an observer of the data loaders consumption must conform to
  */
@@ -38,3 +40,5 @@
                    bytesUploaded:(int)bytesUploaded;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -24,6 +24,8 @@
 @class SPTDataLoaderResponse;
 @class SPTDataLoaderRequest;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The protocol used for listening to the result of performing requests on the SPTDataLoader
  * @discussion One of the following callbacks are guaranteed to happen for every request being track by the data loader:
@@ -78,3 +80,5 @@ didReceiveDataChunk:(NSData *)data
 - (void)dataLoader:(SPTDataLoader *)dataLoader didReceiveInitialResponse:(SPTDataLoaderResponse *)response;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderFactory.h
+++ b/include/SPTDataLoader/SPTDataLoaderFactory.h
@@ -21,6 +21,9 @@
 @import Foundation;
 
 @class SPTDataLoader;
+@protocol SPTDataLoaderAuthoriser;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A factory for producing data loaders and automatically authorising requests
@@ -36,7 +39,7 @@
  * The objects authorising HTTP requests for this factory
  * @discussion The NSArray consists of objects conforming to the SPTDataLoaderAuthoriser protocol
  */
-@property (nonatomic, copy, readonly) NSArray *authorisers;
+@property (nonatomic, copy, readonly, nullable) NSArray<id<SPTDataLoaderAuthoriser>> *authorisers;
 
 /**
  * Creates a data loader
@@ -44,3 +47,5 @@
 - (SPTDataLoader *)createDataLoader;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
+++ b/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
@@ -22,6 +22,8 @@
 
 @class SPTDataLoaderRequest;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A rate limiter for configuring custom rates on a per service basis
  * @discussion A service is defined as the scheme, host and first path component of the URL
@@ -64,3 +66,5 @@
 - (void)setRetryAfter:(NSTimeInterval)absoluteTime forURL:(NSURL *)URL;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -20,6 +20,8 @@
  */
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSInteger, SPTDataLoaderRequestMethod) {
     SPTDataLoaderRequestMethodGet,
     SPTDataLoaderRequestMethodPost,
@@ -51,11 +53,11 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
 /**
  * The body of the request
  */
-@property (nonatomic, strong) NSData *body;
+@property (nonatomic, strong, nullable) NSData *body;
 /**
  * The headers represented by a dictionary
  */
-@property (nonatomic, strong, readonly) NSDictionary *headers;
+@property (nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> *headers;
 /**
  * Whether the result of the request should be delivered in chunks
  * @discussion This will only generate chunks if the data loader delegate is set up to receive them
@@ -77,7 +79,7 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
 /**
  * Any user information tied to this request
  */
-@property (nonatomic, strong) NSDictionary *userInfo;
+@property (nonatomic, strong) NSDictionary<NSObject *, NSObject *> *userInfo;
 /**
  * An identifier for uniquely identifying the request
  */
@@ -93,14 +95,14 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
  *
  * @discussion This is used for logging purposes to locate where data is downloaded from.
  */
-@property (nonatomic, strong) NSString *sourceIdentifier;
+@property (nonatomic, copy, nullable) NSString *sourceIdentifier;
 
 /**
  * Class constructor
  * @param URL The URL to query
  * @param sourceIdentifier An identifier for the request source. May be nil.
  */
-+ (instancetype)requestWithURL:(NSURL *)URL sourceIdentifier:(NSString *)sourceIdentifier;
++ (instancetype)requestWithURL:(NSURL *)URL sourceIdentifier:(nullable NSString *)sourceIdentifier;
 
 /**
  * The value to be added to the Accept-Language header by default
@@ -120,3 +122,5 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
 - (void)removeHeader:(NSString *)header;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderResolver.h
+++ b/include/SPTDataLoader/SPTDataLoaderResolver.h
@@ -20,6 +20,8 @@
  */
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * An object for keeping track of IP addresses to use for hosts
  */
@@ -35,7 +37,7 @@
  * @param addresses An NSArray of NSString objects denoting an address
  * @param host The host tied to these addresses
  */
-- (void)setAddresses:(NSArray *)addresses forHost:(NSString *)host;
+- (void)setAddresses:(NSArray<NSString *> *)addresses forHost:(NSString *)host;
 /**
  * Mark an address as unreachable
  * @param address The address that has become unreachable
@@ -43,3 +45,5 @@
 - (void)markAddressAsUnreachable:(NSString *)address;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -20,6 +20,8 @@
  */
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
 typedef NS_ENUM(NSInteger, SPTDataLoaderResponseHTTPStatusCode) {
     SPTDataLoaderResponseHTTPStatusCodeInvalid = 0,
@@ -88,23 +90,23 @@ extern NSString * const SPTDataLoaderResponseErrorDomain;
  * The error that the request generated
  * @warning Will be nil if the request is considered a success
  */
-@property (nonatomic, strong, readonly) NSError *error;
+@property (nonatomic, strong, readonly, nullable) NSError *error;
 /**
  * The headers that the server returned with a request
  */
-@property (nonatomic, strong, readonly) NSDictionary *responseHeaders;
+@property (nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> *responseHeaders;
 /**
  * The date at which the request that generated the response can be retried
  * @warning Can be nil if no retry-after is given in the response headers
  * @discussion This should only show up if the response is an error. It can still show up in a successful response, but
  * if this occurs it is probably the result of a misconfigured server
  */
-@property (nonatomic, strong, readonly) NSDate *retryAfter;
+@property (nonatomic, strong, readonly, nullable) NSDate *retryAfter;
 /**
  * The body of data contained in the response
  * @warning Will be nil if not body was contained in the response
  */
-@property (nonatomic, strong, readonly) NSData *body;
+@property (nonatomic, strong, readonly, nullable) NSData *body;
 /**
  * The time the request took
  */
@@ -116,3 +118,5 @@ extern NSString * const SPTDataLoaderResponseErrorDomain;
 @property (nonatomic, assign, readonly) SPTDataLoaderResponseHTTPStatusCode statusCode;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -23,6 +23,9 @@
 @class SPTDataLoaderFactory;
 @class SPTDataLoaderRateLimiter;
 @class SPTDataLoaderResolver;
+@protocol SPTDataLoaderAuthoriser;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPTDataLoaderConsumptionObserver;
 
@@ -50,13 +53,13 @@
 + (instancetype)dataLoaderServiceWithUserAgent:(NSString *)userAgent
                                    rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
                                       resolver:(SPTDataLoaderResolver *)resolver
-                      customURLProtocolClasses:(NSArray *)customURLProtocolClasses;
+                      customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses;
 
 /**
  * Creates a data loader factory
  * @param authorisers An NSArray of SPTDataLoaderAuthoriser objects for supporting different forms of authorisation
  */
-- (SPTDataLoaderFactory *)createDataLoaderFactoryWithAuthorisers:(NSArray *)authorisers;
+- (SPTDataLoaderFactory *)createDataLoaderFactoryWithAuthorisers:(nullable NSArray<id<SPTDataLoaderAuthoriser>> *)authorisers;
 /**
  * Adds a consumption observer
  * @param consumptionObserver The consumption observer to add to the service
@@ -71,3 +74,5 @@
 - (void)removeConsumptionObserver:(id<SPTDataLoaderConsumptionObserver>)consumptionObserver;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This PR adds modern Objective-C annotations to all SPTDataLoader classes, both private and public.

Changes include:
- Adding `NS_ASSUME_NONNULL_BEGIN/END` compiler instructions to all files.
- Where objects are allowed to be `nil`, add the `nullable` annotation.
- Missing `nil`-checks and corresponding `_Nonnull` casts added.
- Some missing assignments to required variables added in tests.
- Where changes required to fully conform to the nullability annotations were considered too big for this commit, or where whether passing `nil` would cause a crash was tested, `#pragma` warning silencers were added.
- Generic annotations were added to all collections, both public & private.

Note: Whether a parameter should be `nullable` or not was determined by inspecting the surrounding code and the tests.

This change heavily improves SPTDataLoader’s usability in Swift, since arguments that before were typed as `[AnyObject]` now get full typing. Nullable properties and arguments are now also correctly treated as optionals in Swift.

This change also has the added benefit of adding more strong typing and safety to the implementation.