### PR TITLE
Remove NSObject type info for userInfo

### DIFF
--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -79,7 +79,7 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
 /**
  * Any user information tied to this request
  */
-@property (nonatomic, strong) NSDictionary<NSObject *, NSObject *> *userInfo;
+@property (nonatomic, strong) NSDictionary *userInfo;
 /**
  * An identifier for uniquely identifying the request
  */


### PR DESCRIPTION
It was causing issues with certain usage patterns where a non-NSObject subclass was saved in the userInfo dictionary. For example the [block interface hacking](https://github.com/spotify/SPTDataLoader#why-no-block-interface).

:crying_cat_face: 

@JohnSundell 