### PR TITLE
Support projects that don't enable clang modules

### DIFF
--- a/SPTDataLoader/NSDictionary+HeaderSize.h
+++ b/SPTDataLoader/NSDictionary+HeaderSize.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @protocol SPTDataLoaderCancellationToken;
 @protocol SPTDataLoaderCancellationTokenDelegate;

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderCancellationTokenFactory.h"
 

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderCancellationToken.h"
 

--- a/SPTDataLoader/SPTDataLoaderExponentialTimer.m
+++ b/SPTDataLoader/SPTDataLoaderExponentialTimer.m
@@ -20,8 +20,8 @@
  */
 #import "SPTDataLoaderExponentialTimer.h"
 
-@import Darwin.C.math;
-@import Darwin.C.stdlib;
+#import <math.h>
+#import <stdlib.h>
 
 
 #pragma mark - Default Values

--- a/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderRequest;
 @class SPTDataLoaderResponse;

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderRequest;
 @class SPTDataLoaderRateLimiter;

--- a/SPTDataLoader/SPTDataLoaderResolverAddress.h
+++ b/SPTDataLoader/SPTDataLoaderResolverAddress.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SPTDataLoaderTests/NSBundleMock.h
+++ b/SPTDataLoaderTests/NSBundleMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSBundleMock : NSBundle
 

--- a/SPTDataLoaderTests/NSDictionaryHeaderSizeTest.m
+++ b/SPTDataLoaderTests/NSDictionaryHeaderSizeTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "NSDictionary+HeaderSize.h"
 

--- a/SPTDataLoaderTests/NSURLSessionDataTaskMock.h
+++ b/SPTDataLoaderTests/NSURLSessionDataTaskMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSURLSessionDataTaskMock : NSURLSessionDataTask
 

--- a/SPTDataLoaderTests/NSURLSessionMock.h
+++ b/SPTDataLoaderTests/NSURLSessionMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class NSURLSessionDataTaskMock;
 

--- a/SPTDataLoaderTests/NSURLSessionTaskMock.h
+++ b/SPTDataLoaderTests/NSURLSessionTaskMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSURLSessionTaskMock : NSURLSessionTask
 

--- a/SPTDataLoaderTests/SPTDataLoaderAuthoriserMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderAuthoriserMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderAuthoriser.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenDelegateMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderCancellationToken.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderCancellationTokenFactoryImplementation.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenImplementationTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenImplementationTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderCancellationTokenImplementation.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderConsumptionObserverMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderConsumptionObserver.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderDelegateMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderDelegate.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderExponentialTimerTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderExponentialTimerTest.m
@@ -18,9 +18,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
-@import SPTDataLoader;
+#import <SPTDataLoader/SPTDataLoader.h>
 
 @interface SPTDataLoaderExponentialTimerTest : XCTestCase
 

--- a/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderFactory.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderRateLimiterTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRateLimiterTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderRateLimiter.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderRequestResponseHandler.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderRequestResponseHandler.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderRequestTaskHandler.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -18,11 +18,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <SPTDataLoader/SPTDataLoaderRequest.h>
 
-@import ObjectiveC;
+#import <ObjectiveC/ObjectiveC.h>
 
 #import "SPTDataLoaderRequest+Private.h"
 #import "NSBundleMock.h"

--- a/SPTDataLoaderTests/SPTDataLoaderResolverAddressTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResolverAddressTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderResolverAddress.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderResolverTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResolverTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderResolver.h"
 

--- a/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderResponse.h"
 #import "SPTDataLoaderRequest.h"

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import <SPTDataLoader/SPTDataLoaderService.h>
 #import <SPTDataLoader/SPTDataLoaderRequest.h>

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "SPTDataLoaderRequest.h"
 

--- a/demo/AppDelegate.h
+++ b/demo/AppDelegate.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @class SPTDataLoaderService;
 @class SPTDataLoaderFactory;

--- a/demo/AppDelegate.m
+++ b/demo/AppDelegate.m
@@ -20,7 +20,7 @@
  */
 #import "AppDelegate.h"
 
-@import SPTDataLoader;
+#import <SPTDataLoader/SPTDataLoader.h>
 
 #import "SPTDataLoaderAuthoriserOAuth.h"
 #import "NSString+OAuthBlob.h"

--- a/demo/NSString+OAuthBlob.h
+++ b/demo/NSString+OAuthBlob.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSString (OAuthBlob)
 

--- a/demo/PlaylistsViewController.h
+++ b/demo/PlaylistsViewController.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @class PlaylistsViewModel;
 

--- a/demo/PlaylistsViewModel.h
+++ b/demo/PlaylistsViewModel.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class PlaylistsViewModel;
 @class SPTDataLoader;

--- a/demo/PlaylistsViewModel.m
+++ b/demo/PlaylistsViewModel.m
@@ -20,7 +20,7 @@
  */
 #import "PlaylistsViewModel.h"
 
-@import SPTDataLoader;
+#import <SPTDataLoader/SPTDataLoader.h>
 
 static NSString * const PlaylistsViewModelMeURLString = @"https://api.spotify.com/v1/me";
 static NSString * const PlaylistsViewModelSourceIdentifier = @"me";

--- a/demo/SPTDataLoaderAuthoriserOAuth.h
+++ b/demo/SPTDataLoaderAuthoriserOAuth.h
@@ -18,9 +18,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
-@import SPTDataLoader;
+#import <SPTDataLoader/SPTDataLoader.h>
 
 @interface SPTDataLoaderAuthoriserOAuth : NSObject <SPTDataLoaderAuthoriser>
 

--- a/demo/ViewController.h
+++ b/demo/ViewController.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @interface ViewController : UIViewController
 

--- a/demo/ViewController.m
+++ b/demo/ViewController.m
@@ -21,7 +21,7 @@
 #import "ViewController.h"
 #import "ClientKeys.h"
 
-@import SPTDataLoader;
+#import <SPTDataLoader/SPTDataLoader.h>
 
 @implementation ViewController
 

--- a/demo/main.m
+++ b/demo/main.m
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 #import "AppDelegate.h"
 

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #import <SPTDataLoader/SPTDataLoaderConvenience.h>
 

--- a/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
+++ b/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderRequest;
 

--- a/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
+++ b/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @protocol SPTDataLoaderCancellationToken;
 

--- a/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
+++ b/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderResponse;
 

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoader;
 @class SPTDataLoaderResponse;

--- a/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
+++ b/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #pragma mark - Default Jitter Values
 

--- a/include/SPTDataLoader/SPTDataLoaderFactory.h
+++ b/include/SPTDataLoader/SPTDataLoaderFactory.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoader;
 @protocol SPTDataLoaderAuthoriser;

--- a/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
+++ b/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderRequest;
 

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/SPTDataLoader/SPTDataLoaderResolver.h
+++ b/include/SPTDataLoader/SPTDataLoaderResolver.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class SPTDataLoaderFactory;
 @class SPTDataLoaderRateLimiter;


### PR DESCRIPTION
Projects that don't have clang modules enabled currently can't support including our project. Switching to `#import` will work with both cases. When modules are enabled, these are implicitly converted to clang module imports.

@8W9aG @rastersize @jgavris