### PR TITLE
Fix nil-returns from methods with nonnull return type

### DIFF
--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPTDataLoader ()
 
-@property (nonatomic, strong) NSHashTable<id<SPTDataLoaderCancellationToken>> *cancellationTokens;
-@property (nonatomic, strong) NSMutableArray<SPTDataLoaderRequest *> *requests;
+@property (nonatomic, strong, readonly) NSHashTable<id<SPTDataLoaderCancellationToken>> *cancellationTokens;
+@property (nonatomic, strong, readonly) NSMutableArray<SPTDataLoaderRequest *> *requests;
 
 @end
 
@@ -46,16 +46,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
 {
-    if (!(self = [super init])) {
-        return nil;
+    self = [super init];
+    if (self) {
+        _requestResponseHandlerDelegate = requestResponseHandlerDelegate;
+
+        _cancellationTokens = [NSHashTable weakObjectsHashTable];
+        _delegateQueue = dispatch_get_main_queue();
+        _requests = [NSMutableArray new];
     }
-    
-    _requestResponseHandlerDelegate = requestResponseHandlerDelegate;
-    
-    _cancellationTokens = [NSHashTable weakObjectsHashTable];
-    _delegateQueue = dispatch_get_main_queue();
-    _requests = [NSMutableArray new];
-    
     return self;
 }
 

--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark SPTDataLoader
 
-- (id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request
+- (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request
 {
     SPTDataLoaderRequest *copiedRequest = [request copy];
     id<SPTDataLoaderDelegate> delegate = self.delegate;

--- a/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
+++ b/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
@@ -41,12 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate cancelObject:(nullable id)cancelObject
 {
-    if (!(self = [super init])) {
-        return nil;
+    self = [super init];
+    if (self) {
+        _delegate = delegate;
+        _objectToCancel = cancelObject;
     }
-    
-    _delegate = delegate;
-    _objectToCancel = cancelObject;
     
     return self;
 }

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -50,18 +50,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRequestResponseHandlerDelegate:(nullable id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
                                            authorisers:(nullable NSArray<id<SPTDataLoaderAuthoriser>> *)authorisers
 {
-    if (!(self = [super init])) {
-        return nil;
-    }
-    
-    _requestResponseHandlerDelegate = requestResponseHandlerDelegate;
-    _authorisers = [authorisers copy];
-    
-    _requestToRequestResponseHandler = [NSMapTable weakToWeakObjectsMapTable];
-    _requestTimeoutQueue = dispatch_get_main_queue();
+    self = [super init];
+    if (self) {
+        _requestResponseHandlerDelegate = requestResponseHandlerDelegate;
+        _authorisers = [authorisers copy];
 
-    for (id<SPTDataLoaderAuthoriser> authoriser in _authorisers) {
-        authoriser.delegate = self;
+        _requestToRequestResponseHandler = [NSMapTable weakToWeakObjectsMapTable];
+        _requestTimeoutQueue = dispatch_get_main_queue();
+
+        for (id<SPTDataLoaderAuthoriser> authoriser in _authorisers) {
+            authoriser.delegate = self;
+        }
     }
     
     return self;

--- a/SPTDataLoader/SPTDataLoaderRateLimiter.m
+++ b/SPTDataLoader/SPTDataLoaderRateLimiter.m
@@ -45,14 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDefaultRequestsPerSecond:(double)requestsPerSecond
 {
-    if (!(self = [super init])) {
-        return nil;
+    self = [super init];
+    if (self) {
+        _requestsPerSecond = requestsPerSecond;
+        _serviceEndpointRequestsPerSecond = [NSMutableDictionary new];
+        _serviceEndpointLastExecution = [NSMutableDictionary new];
+        _serviceEndpointRetryAt = [NSMutableDictionary new];
     }
-    
-    _requestsPerSecond = requestsPerSecond;
-    _serviceEndpointRequestsPerSecond = [NSMutableDictionary new];
-    _serviceEndpointLastExecution = [NSMutableDictionary new];
-    _serviceEndpointRetryAt = [NSMutableDictionary new];
     
     return self;
 }
@@ -135,10 +134,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)serviceKeyFromURL:(NSURL *)URL
 {
-    if (!URL) {
-        return nil;
-    }
-    
     NSURLComponents *requestComponents = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
     NSURLComponents *serviceComponents = [NSURLComponents new];
     serviceComponents.scheme = requestComponents.scheme;

--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -51,17 +51,16 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
 {
     static int64_t uniqueIdentifierBarrier = 0;
 
-    if (!(self = [super init])) {
-        return nil;
-    }
+    self = [super init];
+    if (self) {
+        _URL = URL;
+        _sourceIdentifier = sourceIdentifier;
 
-    _URL = URL;
-    _sourceIdentifier = sourceIdentifier;
-
-    _mutableHeaders = [NSMutableDictionary new];
-    _method = SPTDataLoaderRequestMethodGet;
-    @synchronized(self.class) {
-        _uniqueIdentifier = uniqueIdentifierBarrier++;
+        _mutableHeaders = [NSMutableDictionary new];
+        _method = SPTDataLoaderRequestMethodGet;
+        @synchronized(self.class) {
+            _uniqueIdentifier = uniqueIdentifierBarrier++;
+        }
     }
 
     return self;

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -66,8 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Tell the operation the URL session has completed the request
  * @param error An optional error to use if the request was not completed successfully
+ * @return The response object unless the request was cancelled or will be re-tried in which case `nil` is returned.
  */
-- (SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error;
+- (nullable SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error;
 /**
  * Gets called whenever the original request was redirected.
  * Returns YES to allow redirect, NO to block it.

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -112,7 +112,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
     }];
 }
 
-- (SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error
+- (nullable SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error
 {
     id<SPTDataLoaderRequestResponseHandler> requestResponseHandler = self.requestResponseHandler;
     if (!self.response) {

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -77,23 +77,22 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 {
     const NSTimeInterval SPTDataLoaderRequestTaskHandlerMaximumTime = 60.0;
     const NSTimeInterval SPTDataLoaderRequestTaskHandlerInitialTime = 1.0;
-    
-    if (!(self = [super init])) {
-        return nil;
+
+    self = [super init];
+    if (self) {
+        _task = task;
+        _request = request;
+        _requestResponseHandler = requestResponseHandler;
+        _rateLimiter = rateLimiter;
+
+        __weak __typeof(self) weakSelf = self;
+        _executionBlock = ^{
+            [weakSelf checkRateLimiterAndExecute];
+        };
+        _exponentialTimer = [SPTDataLoaderExponentialTimer exponentialTimerWithInitialTime:SPTDataLoaderRequestTaskHandlerInitialTime
+                                                                                   maxTime:SPTDataLoaderRequestTaskHandlerMaximumTime];
+        _retryQueue = dispatch_get_main_queue();
     }
-    
-    _task = task;
-    _request = request;
-    _requestResponseHandler = requestResponseHandler;
-    _rateLimiter = rateLimiter;
-    
-    __weak __typeof(self) weakSelf = self;
-    _executionBlock = ^ {
-        [weakSelf checkRateLimiterAndExecute];
-    };
-    _exponentialTimer = [SPTDataLoaderExponentialTimer exponentialTimerWithInitialTime:SPTDataLoaderRequestTaskHandlerInitialTime
-                                                                               maxTime:SPTDataLoaderRequestTaskHandlerMaximumTime];
-    _retryQueue = dispatch_get_main_queue();
     
     return self;
 }

--- a/SPTDataLoader/SPTDataLoaderResolverAddress.m
+++ b/SPTDataLoader/SPTDataLoaderResolverAddress.m
@@ -24,8 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPTDataLoaderResolverAddress ()
 
-@property (nonatomic, assign) NSTimeInterval stalePeriod;
-
+@property (nonatomic, assign, readonly) NSTimeInterval stalePeriod;
 @property (nonatomic, assign) CFAbsoluteTime lastFailedTime;
 
 @end
@@ -53,13 +52,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAddress:(NSString *)address
 {
     const NSTimeInterval SPTDataLoaderResolverAddressDefaultStalePeriodOneHour = 60.0 * 60.0;
-    
-    if (!(self = [super init])) {
-        return nil;
+
+    self = [super init];
+    if (self) {
+        _address = address;
+        _stalePeriod = SPTDataLoaderResolverAddressDefaultStalePeriodOneHour;
     }
-    
-    _address = address;
-    _stalePeriod = SPTDataLoaderResolverAddressDefaultStalePeriodOneHour;
     
     return self;
 }

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -49,26 +49,25 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 - (instancetype)initWithRequest:(SPTDataLoaderRequest *)request response:(nullable NSURLResponse *)response
 {
-    if (!(self = [super init])) {
-        return nil;
-    }
-    
-    _request = request;
-    _response = response;
-    
-    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-        if (httpResponse.statusCode >= SPTDataLoaderResponseHTTPStatusCodeMovedMultipleChoices
-            || httpResponse.statusCode <= SPTDataLoaderResponseHTTPStatusCodeSwitchProtocols) {
-            _error = [NSError errorWithDomain:SPTDataLoaderResponseErrorDomain
-                                         code:httpResponse.statusCode
-                                     userInfo:nil];
+    self = [super init];
+    if (self) {
+        _request = request;
+        _response = response;
+
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+            if (httpResponse.statusCode >= SPTDataLoaderResponseHTTPStatusCodeMovedMultipleChoices
+                || httpResponse.statusCode <= SPTDataLoaderResponseHTTPStatusCodeSwitchProtocols) {
+                _error = [NSError errorWithDomain:SPTDataLoaderResponseErrorDomain
+                                             code:httpResponse.statusCode
+                                         userInfo:nil];
+            }
+            _responseHeaders = httpResponse.allHeaderFields;
+            _statusCode = httpResponse.statusCode;
         }
-        _responseHeaders = httpResponse.allHeaderFields;
-        _statusCode = httpResponse.statusCode;
+
+        _retryAfter = [self retryAfterForHeaders:_responseHeaders];
     }
-    
-    _retryAfter = [self retryAfterForHeaders:_responseHeaders];
     
     return self;
 }

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -43,21 +43,32 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SPTDataLoader : NSObject
 
+#pragma mark Delegating Tasks
+
 /**
- * The object listening to the data loader
+ * The object listening to the data loader.
  */
 @property (nonatomic, weak, nullable) id<SPTDataLoaderDelegate> delegate;
 /**
- * The queue to call the delegate selectors on
- * @discussion By default this is the main queue
+ * The queue to call the delegate selectors on.
+ * @discussion By default this is the main queue.
  */
 @property (nonatomic, strong) dispatch_queue_t delegateQueue;
 
+#pragma mark Performing Requests
+
 /**
- * Performs a request
+ * Performs a request and returns a cancellation token associated with it.
+ * @discussion If the request can’t be performed `nil` will be returned and the receiver’s delegate will be sent the
+ * `dataLoader:didReceiveErrorResponse:`. The response object sent to the delegate will contain an `NSError` object
+ * describing what went wrong.
  * @param request The object describing the kind of request to be performed
+ * @return A cancellation token associated with the request, or `nil` if the request coulnd’t be performed.
  */
-- (id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request;
+- (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request;
+
+#pragma mark Cancelling Loads
+
 /**
  * Cancels all the currently operating and pending requests
  */


### PR DESCRIPTION
Caught by running the analyzer bundled with Xcode 7.3 beta 3. Most of the problems were due to the early-return segment of the init methods:
![early return nil analyzer warning](https://cloud.githubusercontent.com/assets/23453/13219260/26dca126-d96f-11e5-8c60-01ff9c5aa4a5.png)

Also fixed a the type of some methods that should return `nil` as well as updated the documentation for those.

@spotify/objc-dev 
