### PR TITLE
Move -debugDescription implementation to -description method for improved debugability

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -177,9 +177,9 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
     return [languageHeaderValues componentsJoinedByString:SPTDataLoaderRequestLanguageHeaderValuesJoiner];
 }
 
-- (NSString *)debugDescription
+- (NSString *)description
 {
-    return [NSString stringWithFormat:@"%@ { URL: %@ }", [super debugDescription], self.URL];
+    return [NSString stringWithFormat:@"<%@: %p URL = \"%@\">", self.class, (void *)self, self.URL];
 }
 
 #pragma mark NSCopying

--- a/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/SPTDataLoader/SPTDataLoaderResponse.m
@@ -182,9 +182,9 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
     return [httpDateFormatter dateFromString:retryAfterValue];
 }
 
-- (NSString *)debugDescription
+- (NSString *)description
 {
-    return [NSString stringWithFormat:@"%@ { URL: %@ } { status code: %ld, headers: %@ }", [super debugDescription], self.response.URL, (long)self.statusCode, self.responseHeaders];
+    return [NSString stringWithFormat:@"<%@: %p URL = \"%@\"; status-code = %ld; headers = %@>", self.class, (void *)self, self.response.URL, (long)self.statusCode, self.responseHeaders];
 }
 
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -173,14 +173,14 @@
     XCTAssertEqualObjects(@"fr-CA, pt-PT;q=0.50, en;q=0.01", languageValues);
 }
 
-- (void)testDebugDescription
+- (void)testDescription
 {
-    XCTAssertNotNil(self.request.debugDescription,
-                    @"The debugDescription shouldn't be nil.");
+    XCTAssertNotNil(self.request.description,
+                    @"The description shouldn't be nil.");
     
-    NSString *URLString = [NSString stringWithFormat:@"URL: %@", self.URL.absoluteString];
-    XCTAssertTrue([self.request.debugDescription containsString:URLString],
-                  @"The debugDescription should contain the URL of the request.");
+    NSString *URLString = [NSString stringWithFormat:@"URL = \"%@\"", self.URL.absoluteString];
+    XCTAssertTrue([self.request.description containsString:URLString],
+                  @"The description should contain the URL of the request.");
 }
 
 - (void)testAcceptLanguageWithMultipleLanguagesContainingEnglish

--- a/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderResponseTest.m
@@ -184,22 +184,22 @@
     XCTAssertFalse(shouldRetry, @"The response should not retry when the connection was cancelled");
 }
 
-- (void)testDebugDescription
+- (void)testDescription
 {
-    XCTAssertNotNil(self.response.debugDescription,
-                    @"The debugDescription shouldn't be nil.");
+    XCTAssertNotNil(self.response.description,
+                    @"The description shouldn't be nil.");
     
-    NSString *URLString = [NSString stringWithFormat:@"URL: %@", self.urlResponse.URL];
-    XCTAssertTrue([self.response.debugDescription containsString:URLString],
-                  @"The debugDescription should contain the URL of the response");
+    NSString *URLString = [NSString stringWithFormat:@"URL = \"%@\"", self.urlResponse.URL];
+    XCTAssertTrue([self.response.description containsString:URLString],
+                  @"The description should contain the URL of the response");
     
-    NSString *statusCodeString = [NSString stringWithFormat:@"status code: %ld", (long)self.response.statusCode];
-    XCTAssertTrue([self.response.debugDescription containsString:statusCodeString],
-                  @"The debugDescription should contain the status code of the response");
+    NSString *statusCodeString = [NSString stringWithFormat:@"status-code = %ld", (long)self.response.statusCode];
+    XCTAssertTrue([self.response.description containsString:statusCodeString],
+                  @"The description should contain the status code of the response");
     
-    NSString *headersString = [NSString stringWithFormat:@"headers: %@", self.response.responseHeaders];
-    XCTAssertTrue([self.response.debugDescription containsString:headersString],
-                  @"The debugDescription should contain the headers code of the response");
+    NSString *headersString = [NSString stringWithFormat:@"headers = %@", self.response.responseHeaders];
+    XCTAssertTrue([self.response.description containsString:headersString],
+                  @"The description should contain the headers code of the response");
 }
 
 


### PR DESCRIPTION
This PR moves the `-debugDescription` implementation to the `-description` method instead. The reasoning being that it makes debugging easier if a request or response object is logged instead of printed using the debugger.

Also aligns the format with Apple’s standard (`<ClassName: 0xDEADBEEF property-1 = "string value"; property-2 = 42>`).

@spotify/objc-dev 