### PR TITLE
Podspec fixes

### DIFF
--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name         = "SPTDataLoader"
     s.version      = "1.1.0"
-    s.summary      = "SPTDataLoader is Spotify's HTTP library for Objective-C"
+    s.summary      = "SPTDataLoader is Spotify’s HTTP library for Objective-C"
 
     s.description  = <<-DESC
                         Authentication and back-off logic is a pain, let’s do it

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
                         making HTTP requests.
                      DESC
 
-    s.ios.deployment_target = "7.0"
-    s.osx.deployment_target = "10.9"
-    s.tvos.deployment_target = '9.0'
-    s.watchos.deployment_target = '2.0'
+    s.ios.deployment_target     = "7.0"
+    s.osx.deployment_target     = "10.9"
+    s.tvos.deployment_target    = "9.0"
+    s.watchos.deployment_target = "2.0"
 
     s.homepage     = "https://github.com/spotify/SPTDataLoader"
     s.license      = "Apache 2.0"
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
     s.source       = { :git => "https://github.com/spotify/SPTDataLoader.git", :tag => s.version }
     s.source_files = "include/SPTDataLoader/*.h", "SPTDataLoader/*.{h,m}"
     s.public_header_files = "include/SPTDataLoader/*.h"
-    s.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+    s.xcconfig = { "OTHER_LDFLAGS" => "-lObjC" }
 
 end

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
                         making HTTP requests.
                      DESC
 
-    s.ios.deployment_target = "6.0"
+    s.ios.deployment_target = "7.0"
     s.osx.deployment_target = "10.9"
     s.tvos.deployment_target = '9.0'
     s.watchos.deployment_target = '2.0'

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -16,9 +16,10 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target    = "9.0"
     s.watchos.deployment_target = "2.0"
 
-    s.homepage  = "https://github.com/spotify/SPTDataLoader"
-    s.license   = "Apache 2.0"
-    s.author    = {
+    s.homepage          = "https://github.com/spotify/SPTDataLoader"
+    s.social_media_url  = "https://twitter.com/spotifyeng"
+    s.license           = "Apache 2.0"
+    s.author            = {
         "Will Sackfield" => "sackfield@spotify.com"
     }
 

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -16,12 +16,17 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target    = "9.0"
     s.watchos.deployment_target = "2.0"
 
-    s.homepage     = "https://github.com/spotify/SPTDataLoader"
-    s.license      = "Apache 2.0"
-    s.author       = { "Will Sackfield" => "sackfield@spotify.com" }
-    s.source       = { :git => "https://github.com/spotify/SPTDataLoader.git", :tag => s.version }
-    s.source_files = "include/SPTDataLoader/*.h", "SPTDataLoader/*.{h,m}"
-    s.public_header_files = "include/SPTDataLoader/*.h"
-    s.xcconfig = { "OTHER_LDFLAGS" => "-lObjC" }
+    s.homepage  = "https://github.com/spotify/SPTDataLoader"
+    s.license   = "Apache 2.0"
+    s.author    = {
+        "Will Sackfield" => "sackfield@spotify.com"
+    }
+
+    s.source                = { :git => "https://github.com/spotify/SPTDataLoader.git", :tag => s.version }
+    s.source_files          = "include/SPTDataLoader/*.h", "SPTDataLoader/*.{h,m}"
+    s.public_header_files   = "include/SPTDataLoader/*.h"
+    s.xcconfig              = {
+        "OTHER_LDFLAGS" => "-lObjC"
+    }
 
 end


### PR DESCRIPTION
Fixes some issues, adds some more stuff and standardizes the podspec.

- Adds a link to our [Spotify Engineering Twitter](http://twitter.com/spotifyeng) account.
- Fixes iOS deployment target. It was set to 6.0 even though we only support 7.0 and up.
- Fixes use of incorrect apostrophe character.
- Re-formats the podspec making sure we use only one type of quote character. As well as some other small changes to the formatting.

@spotify/objc-dev 