### PR TITLE
Fix BAD_POINTER_COMPARISON (infer warning)

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRateLimiter.m
+++ b/SPTDataLoader/SPTDataLoaderRateLimiter.m
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     @synchronized(self.serviceEndpointRequestsPerSecond) {
         NSNumber *value = self.serviceEndpointRequestsPerSecond[serviceKey];
-        return value ? value.doubleValue : self.requestsPerSecond;
+        return (value != nil) ? value.doubleValue : self.requestsPerSecond;
     }
 }
 


### PR DESCRIPTION
Should fix this:

SPTDataLoaderRateLimiter.m 
`131`: Implicitly checking whether `NSNumber` pointer value is nil at line `131`, column `16`. Did you mean to compare against the unboxed value instead? Please either explicitly compare value to nil or use one of the `NSNumber` accessors before the comparison.