### PR TITLE
Fix cancellation race condition

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		059940A51A14FA65006D6BE9 /* SPTDataLoaderCancellationTokenDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 059940A41A14FA65006D6BE9 /* SPTDataLoaderCancellationTokenDelegateMock.m */; };
 		059940A71A150275006D6BE9 /* SPTDataLoaderRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 059940A61A150275006D6BE9 /* SPTDataLoaderRequestTest.m */; };
 		059940A91A150C90006D6BE9 /* SPTDataLoaderResponseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 059940A81A150C90006D6BE9 /* SPTDataLoaderResponseTest.m */; };
+		05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */; };
 		05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */; };
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
 		EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */; };
@@ -145,6 +146,8 @@
 		059940A41A14FA65006D6BE9 /* SPTDataLoaderCancellationTokenDelegateMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderCancellationTokenDelegateMock.m; sourceTree = "<group>"; };
 		059940A61A150275006D6BE9 /* SPTDataLoaderRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTest.m; sourceTree = "<group>"; };
 		059940A81A150C90006D6BE9 /* SPTDataLoaderResponseTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderResponseTest.m; sourceTree = "<group>"; };
+		05A3BCB41D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCancellationTokenFactoryMock.h; sourceTree = "<group>"; };
+		05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderCancellationTokenFactoryMock.m; sourceTree = "<group>"; };
 		05C602FC1CCBBC5E00143BA4 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ci/spotify_os.xcconfig; sourceTree = "<group>"; };
 		05CB0C431A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderRequestTaskHandler.h; sourceTree = "<group>"; };
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
@@ -334,6 +337,8 @@
 				EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */,
 				05EEB73D1C5C090B00A82266 /* NSBundleMock.h */,
 				05EEB73E1C5C090B00A82266 /* NSBundleMock.m */,
+				05A3BCB41D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.h */,
+				05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -497,6 +502,7 @@
 				0599409D1A14F32A006D6BE9 /* SPTDataLoaderRequestResponseHandlerDelegateMock.m in Sources */,
 				055AEE521A16117E00A490BF /* NSURLSessionTaskMock.m in Sources */,
 				055AEE561A162C5E00A490BF /* SPTDataLoaderResolverTest.m in Sources */,
+				05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */,
 				059940971A14E7F1006D6BE9 /* SPTDataLoaderFactoryTest.m in Sources */,
 				055AEE581A162F0200A490BF /* SPTDataLoaderResolverAddressTest.m in Sources */,
 				0504CB911A151C8600AD54EF /* SPTDataLoaderRequestTaskHandlerTest.m in Sources */,

--- a/SPTDataLoader/SPTDataLoader+Private.h
+++ b/SPTDataLoader/SPTDataLoader+Private.h
@@ -22,6 +22,8 @@
 
 #import "SPTDataLoaderRequestResponseHandler.h"
 
+@protocol SPTDataLoaderCancellationTokenFactory;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -32,8 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Class constructor
  * @param requestResponseHandlerDelegate The private delegate for delegating the request handling
+ * @param cancellationTokenFactory The object used to create cancellation tokens
  */
-+ (instancetype)dataLoaderWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate;
++ (instancetype)dataLoaderWithRequestResponseHandlerDelegate:(id<SPTDataLoaderRequestResponseHandlerDelegate>)requestResponseHandlerDelegate
+                                    cancellationTokenFactory:(id<SPTDataLoaderCancellationTokenFactory>)cancellationTokenFactory;
 
 @end
 

--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -190,7 +190,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cancellationTokenDidCancel:(id<SPTDataLoaderCancellationToken>)cancellationToken
 {
-    [self cancelledRequest:(SPTDataLoaderRequest *)cancellationToken.objectToCancel];
+    SPTDataLoaderRequest *request = (SPTDataLoaderRequest *)cancellationToken.objectToCancel;
+    [self.requestResponseHandlerDelegate requestResponseHandler:self cancelRequest:request];
+    [self cancelledRequest:request];
 }
 
 @end

--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -25,6 +25,7 @@
 #import "SPTDataLoaderRequestResponseHandler.h"
 #import "SPTDataLoaderDelegate.h"
 #import "SPTDataLoaderResponse+Private.h"
+#import "SPTDataLoaderCancellationTokenFactoryImplementation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) NSHashTable<id<SPTDataLoaderCancellationToken>> *cancellationTokens;
 @property (nonatomic, strong, readonly) NSMutableArray<SPTDataLoaderRequest *> *requests;
+@property (nonatomic, strong, readonly) id<SPTDataLoaderCancellationTokenFactory> cancellationTokenFactory;
 
 @end
 
@@ -53,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         _cancellationTokens = [NSHashTable weakObjectsHashTable];
         _delegateQueue = dispatch_get_main_queue();
         _requests = [NSMutableArray new];
+        _cancellationTokenFactory = [SPTDataLoaderCancellationTokenFactoryImplementation new];
     }
     return self;
 }

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -162,8 +162,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark SPTDataLoaderRequestResponseHandlerDelegate
 
-- (nullable id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                                       performRequest:(SPTDataLoaderRequest *)request
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                performRequest:(SPTDataLoaderRequest *)request
 {
     if (self.offline) {
         request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
                        });
     }
     
-    return [self.requestResponseHandlerDelegate requestResponseHandler:self performRequest:request];
+    [self.requestResponseHandlerDelegate requestResponseHandler:self performRequest:request];
 }
 
 #pragma mark SPTDataLoaderAuthoriserDelegate

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -22,6 +22,7 @@
 
 #import "SPTDataLoaderAuthoriser.h"
 #import "SPTDataLoaderRequest.h"
+#import "SPTDataLoaderCancellationTokenFactoryImplementation.h"
 
 #import "SPTDataLoaderFactory+Private.h"
 #import "SPTDataLoader+Private.h"
@@ -70,7 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SPTDataLoader *)createDataLoader
 {
-    return [SPTDataLoader dataLoaderWithRequestResponseHandlerDelegate:self];
+    id<SPTDataLoaderCancellationTokenFactory> cancellationTokenFactory = [SPTDataLoaderCancellationTokenFactoryImplementation new];
+    return [SPTDataLoader dataLoaderWithRequestResponseHandlerDelegate:self
+                                              cancellationTokenFactory:cancellationTokenFactory];
 }
 
 #pragma mark SPTDataLoaderRequestResponseHandler

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -195,6 +195,12 @@ NS_ASSUME_NONNULL_BEGIN
     [self.requestResponseHandlerDelegate requestResponseHandler:self performRequest:request];
 }
 
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                 cancelRequest:(SPTDataLoaderRequest *)request
+{
+    [self.requestResponseHandlerDelegate requestResponseHandler:requestResponseHandler cancelRequest:request];
+}
+
 #pragma mark SPTDataLoaderAuthoriserDelegate
 
 - (void)dataLoaderAuthoriser:(id<SPTDataLoaderAuthoriser>)dataLoaderAuthoriser

--- a/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -41,6 +41,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
                 performRequest:(SPTDataLoaderRequest *)request;
+/**
+ * Cancels a request
+ * @param requestResponseHandler The object that can perform cancels
+ * @param request The object describing the request to cancel
+ */
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                 cancelRequest:(SPTDataLoaderRequest *)request;
 
 @optional
 

--- a/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -39,8 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param requestResponseHandler The object that can perform requests and responses
  * @param request The object describing the request to perform
  */
-- (nullable id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                                       performRequest:(SPTDataLoaderRequest *)request;
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                performRequest:(SPTDataLoaderRequest *)request;
 
 @optional
 

--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -200,6 +200,21 @@ requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseH
 }
 
 - (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                 cancelRequest:(SPTDataLoaderRequest *)request
+{
+    NSArray *handlers = nil;
+    @synchronized(self.handlers) {
+        handlers = [self.handlers copy];
+    }
+    for (SPTDataLoaderRequestTaskHandler *handler in handlers) {
+        if ([handler.request isEqual:request]) {
+            [handler.task cancel];
+            break;
+        }
+    }
+}
+
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
              authorisedRequest:(SPTDataLoaderRequest *)request
 {
     [self performRequest:request requestResponseHandler:requestResponseHandler];
@@ -212,24 +227,6 @@ requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseH
     SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
     response.error = error;
     [requestResponseHandler failedResponse:response];
-}
-
-#pragma mark SPTCancellationTokenDelegate
-
-- (void)cancellationTokenDidCancel:(id<SPTDataLoaderCancellationToken>)cancellationToken
-{
-    SPTDataLoaderRequest *request = (SPTDataLoaderRequest *)cancellationToken.objectToCancel;
-    
-    NSArray *handlers = nil;
-    @synchronized(self.handlers) {
-        handlers = [self.handlers copy];
-    }
-    for (SPTDataLoaderRequestTaskHandler *handler in handlers) {
-        if ([handler.request isEqual:request]) {
-            [handler.task cancel];
-            break;
-        }
-    }
 }
 
 #pragma mark NSURLSessionDataDelegate

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+#import "SPTDataLoaderCancellationTokenFactory.h"
+
+@interface SPTDataLoaderCancellationTokenFactoryMock : NSObject <SPTDataLoaderCancellationTokenFactory>
+
+@property (nonatomic, strong, readwrite) id<SPTDataLoaderCancellationTokenDelegate> overridingDelegate;
+
+@end

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.h
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 #import <Foundation/Foundation.h>
 
 #import "SPTDataLoaderCancellationTokenFactory.h"

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.m
@@ -1,0 +1,14 @@
+#import "SPTDataLoaderCancellationTokenFactoryMock.h"
+
+#import "SPTDataLoaderCancellationTokenImplementation.h"
+
+@implementation SPTDataLoaderCancellationTokenFactoryMock
+
+- (id<SPTDataLoaderCancellationToken>)createCancellationTokenWithDelegate:(id<SPTDataLoaderCancellationTokenDelegate>)delegate
+                                                             cancelObject:(id)cancelObject
+{
+    return [SPTDataLoaderCancellationTokenImplementation cancellationTokenImplementationWithDelegate:self.overridingDelegate ?: delegate
+                                                                                        cancelObject:cancelObject];
+}
+
+@end

--- a/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderCancellationTokenFactoryMock.m
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 #import "SPTDataLoaderCancellationTokenFactoryMock.h"
 
 #import "SPTDataLoaderCancellationTokenImplementation.h"

--- a/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
@@ -209,4 +209,12 @@
     XCTAssertEqual(requestResponseHandler.numberOfFailedResponseCalls, 1u, @"The request should have been cancelled");
 }
 
+- (void)testForwardCancelToRequestResponseHandlerDelegate
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandler = [SPTDataLoaderRequestResponseHandlerMock new];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    [self.factory requestResponseHandler:requestResponseHandler cancelRequest:request];
+    XCTAssertEqualObjects(request, self.delegate.lastRequestCancelled);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
@@ -29,5 +29,6 @@ typedef id<SPTDataLoaderCancellationToken> (^SPTCancellationTokenCreator)();
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestPerformed;
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestAuthorised;
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestFailed;
+@property (nonatomic, strong, readwrite) SPTDataLoaderRequest *lastRequestCancelled;
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.h
@@ -29,6 +29,5 @@ typedef id<SPTDataLoaderCancellationToken> (^SPTCancellationTokenCreator)();
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestPerformed;
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestAuthorised;
 @property (nonatomic, strong) SPTDataLoaderRequest *lastRequestFailed;
-@property (nonatomic, copy) SPTCancellationTokenCreator tokenCreator;
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.m
@@ -22,16 +22,10 @@
 
 @implementation SPTDataLoaderRequestResponseHandlerDelegateMock
 
-- (id<SPTDataLoaderCancellationToken>)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                              performRequest:(SPTDataLoaderRequest *)request
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                performRequest:(SPTDataLoaderRequest *)request
 {
     self.lastRequestPerformed = request;
-    
-    if (self.tokenCreator) {
-        return self.tokenCreator();
-    }
-    
-    return nil;
 }
 
 - (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
@@ -45,6 +39,12 @@
                          error:(NSError *)error
 {
     self.lastRequestFailed = request;
+}
+
+- (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
+                 cancelRequest:(SPTDataLoaderRequest *)request
+{
+
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerDelegateMock.m
@@ -44,7 +44,7 @@
 - (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
                  cancelRequest:(SPTDataLoaderRequest *)request
 {
-
+    self.lastRequestCancelled = request;
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -539,4 +539,12 @@
     XCTAssertEqual(self.service.handlers.count, 0u);
 }
 
+- (void)testDoNotPerformRequestThatHasNoURL
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    XCTAssertEqual(self.service.handlers.count, 0u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -382,7 +382,8 @@
 - (void)testCancellingLoads
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    NSURL *URL = [NSURL URLWithString:@"http://www.spotify.com"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
     SPTDataLoaderService *service = [SPTDataLoaderService dataLoaderServiceWithUserAgent:@"Spotify Test 1.0"
                                                                              rateLimiter:self.rateLimiter
                                                                                 resolver:self.resolver

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -548,4 +548,17 @@
     XCTAssertEqual(self.service.handlers.count, 0u);
 }
 
+- (void)testCancellingRequestFromHandler
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"https://localhost"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    SPTDataLoaderRequestTaskHandler *handler = self.service.handlers.firstObject;
+    NSURLSessionDataTaskMock *task = [NSURLSessionDataTaskMock new];
+    handler.task = task;
+    [self.service requestResponseHandler:requestResponseHandlerMock cancelRequest:request];
+    XCTAssertEqual(task.numberOfCallsToCancel, 1u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -157,17 +157,6 @@
     XCTAssertEqual(requestResponseHandlerMock.numberOfFailedResponseCalls, 1u, @"The service did not call a failed response on a failed authorisation attempt");
 }
 
-- (void)testCancellationTokenCancelsOperation
-{
-    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    request.URL = (NSURL * _Nonnull)[NSURL URLWithString:@"https://spclient.wg.spotify.com/thing"];
-    id<SPTDataLoaderCancellationToken> cancellationToken = [self.service requestResponseHandler:requestResponseHandlerMock
-                                                                                 performRequest:request];
-    [cancellationToken cancel];
-    XCTAssertEqual(self.session.lastDataTask.numberOfCallsToCancel, 1u, @"The service did not call a cancelled request on a cancellation token cancelling");
-}
-
 - (void)testSessionDidReceiveResponse
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
@@ -373,18 +362,6 @@
          didReceiveChallenge:challenge
            completionHandler:NSURLSessionCompletionHandler];
     XCTAssertEqual(nonNilCompletions, 1, @"There should only be 1 completion once all certificates are not allowed");
-}
-
-- (void)testPerformingCancelledRequest
-{
-    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
-    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    requestResponseHandlerMock.authorising = YES;
-    id<SPTDataLoaderCancellationToken> cancellationToken = [self.service requestResponseHandler:requestResponseHandlerMock
-                                                                                 performRequest:request];
-    [cancellationToken cancel];
-    [self.service requestResponseHandler:requestResponseHandlerMock authorisedRequest:request];
-    XCTAssertEqual(self.service.handlers.count, 0u, @"There should be no handlers for an already cancelled request");
 }
 
 - (void)testDidReceiveChallengeWithEmptyCompletionHandlerDoesNotCrash

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -173,4 +173,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToSuccessfulResponse, 0u);
 }
 
+- (void)testSuccessfulResponseDoesNotEchoToDelegateWithFailedRequest
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    [self.dataLoader failedResponse:response];
+    XCTAssertEqual(self.delegate.numberOfCallsToErrorResponse, 0u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -165,4 +165,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToReceivedInitialResponse, 0u);
 }
 
+- (void)testSuccessfulResponseDoesNotEchoToDelegateWithUntrackedRequest
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    [self.dataLoader successfulResponse:response];
+    XCTAssertEqual(self.delegate.numberOfCallsToSuccessfulResponse, 0u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -189,4 +189,13 @@
     XCTAssertEqual(self.delegate.numberOfCallsToCancelledRequest, 0u);
 }
 
+- (void)testSuccessfulResponseDoesNotEchoToDelegateWithReceivedDataChunkRequest
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    NSData *data = [NSData data];
+    [self.dataLoader receivedDataChunk:data forResponse:response];
+    XCTAssertEqual(self.delegate.numberOfCallsToReceiveDataChunk, 0u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -160,6 +160,7 @@
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     request.chunks = NO;
+    [self.dataLoader performRequest:request];
     SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
     [self.dataLoader receivedInitialResponse:response];
     XCTAssertEqual(self.delegate.numberOfCallsToReceivedInitialResponse, 0u);

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -207,4 +207,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToReceivedInitialResponse, 0u);
 }
 
+- (void)testCancellingCancellationTokenFiresDelegateCancelMessage
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    id<SPTDataLoaderCancellationToken> cancellationToken = [self.dataLoader performRequest:request];
+    [cancellationToken cancel];
+    XCTAssertEqual(self.delegate.numberOfCallsToCancelledRequest, 1u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -199,4 +199,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToReceiveDataChunk, 0u);
 }
 
+- (void)testSuccessfulResponseDoesNotEchoToDelegateWithReceivedInitialResponseRequest
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    [self.dataLoader receivedInitialResponse:response];
+    XCTAssertEqual(self.delegate.numberOfCallsToReceivedInitialResponse, 0u);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderTest.m
@@ -181,4 +181,12 @@
     XCTAssertEqual(self.delegate.numberOfCallsToErrorResponse, 0u);
 }
 
+- (void)testSuccessfulResponseDoesNotEchoToDelegateWithCancelledRequest
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    [self.dataLoader failedResponse:response];
+    XCTAssertEqual(self.delegate.numberOfCallsToCancelledRequest, 0u);
+}
+
 @end


### PR DESCRIPTION
* Currently when the user cancels the cancellation token we receive this delegate callback in the SPTDataLoaderService
* The SPTDataLoaderService then proceeds to cancel the associated data task
* This would then asynchronously cancel the request, once cancelled that message was forwarded up to the SPTDataLoader which would then alert the delegate
* The problem occurs because of the asynchronousity of the data task cancellation, we could theoretically receive an error or success message before we cancel the data task despite the fact that the cancellation came first
* We will solve this problem by cancelling requests in SPTDataLoader instead and disallowing them  to bubbled up to the UI immediately once cancelled, and perform the actual cancel further down the stack