### PR TITLE
Do not increase the unique identifier barrier on copy

### DIFF
--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -214,4 +214,11 @@
     XCTAssertEqualObjects(self.request.urlRequest.HTTPMethod, @"POST");
 }
 
+- (void)testCopyDoesntIncrementUniqueIdentifierBarrier
+{
+    [self.request copy];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:self.URL sourceIdentifier:nil];
+    XCTAssertEqual(request.uniqueIdentifier - 1, self.request.uniqueIdentifier);
+}
+
 @end


### PR DESCRIPTION
* Prevents requests from increasing by 2 on each
perform request rather than just by 1