### PR TITLE
Nullability annotations for user agent, rate limiter and resolver

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)dataLoaderRequestTaskHandlerWithTask:(NSURLSessionTask *)task
                                              request:(SPTDataLoaderRequest *)request
                               requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                         rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter;
+                                         rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter;
 
 /**
  * Call to tell the operation it has received a response

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -36,7 +36,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 @interface SPTDataLoaderRequestTaskHandler ()
 
 @property (nonatomic, weak) id<SPTDataLoaderRequestResponseHandler> requestResponseHandler;
-@property (nonatomic, strong) SPTDataLoaderRateLimiter *rateLimiter;
+@property (nonatomic, strong, nullable) SPTDataLoaderRateLimiter *rateLimiter;
 
 @property (nonatomic, strong) SPTDataLoaderResponse *response;
 @property (nonatomic, strong, nullable) NSMutableData *receivedData;
@@ -62,7 +62,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 + (instancetype)dataLoaderRequestTaskHandlerWithTask:(NSURLSessionTask *)task
                                              request:(SPTDataLoaderRequest *)request
                               requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                         rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
+                                         rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
 {
     return [[self alloc] initWithTask:task
                               request:request
@@ -73,7 +73,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 - (instancetype)initWithTask:(NSURLSessionTask *)task
                      request:(SPTDataLoaderRequest *)request
       requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                 rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
+                 rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
 {
     const NSTimeInterval SPTDataLoaderRequestTaskHandlerMaximumTime = 60.0;
     const NSTimeInterval SPTDataLoaderRequestTaskHandlerInitialTime = 1.0;

--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -38,8 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SPTDataLoaderService () <SPTDataLoaderRequestResponseHandlerDelegate, NSURLSessionDataDelegate, NSURLSessionTaskDelegate>
 
 
-@property (nonatomic, strong) SPTDataLoaderRateLimiter *rateLimiter;
-@property (nonatomic, strong) SPTDataLoaderResolver *resolver;
+@property (nonatomic, strong, nullable) SPTDataLoaderRateLimiter *rateLimiter;
+@property (nonatomic, strong, nullable) SPTDataLoaderResolver *resolver;
 
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, strong) NSOperationQueue *sessionQueue;
@@ -53,17 +53,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark SPTDataLoaderService
 
-+ (instancetype)dataLoaderServiceWithUserAgent:(NSString *)userAgent
-                                   rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
-                                      resolver:(SPTDataLoaderResolver *)resolver
++ (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
+                                   rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                      resolver:(nullable SPTDataLoaderResolver *)resolver
                       customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses
 {
     return [[self alloc] initWithUserAgent:userAgent rateLimiter:rateLimiter resolver:resolver customURLProtocolClasses:customURLProtocolClasses];
 }
 
-- (instancetype)initWithUserAgent:(NSString *)userAgent
-                      rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
-                         resolver:(SPTDataLoaderResolver *)resolver
+- (instancetype)initWithUserAgent:(nullable NSString *)userAgent
+                      rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                         resolver:(nullable SPTDataLoaderResolver *)resolver
          customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses
 {
     const NSTimeInterval SPTDataLoaderServiceTimeoutInterval = 20.0;

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -51,9 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param customURLProtocolClasses Array of NSURLProtocol Class objects that you want
  *                                 to use for this DataLoaderService. May be nil.
  */
-+ (instancetype)dataLoaderServiceWithUserAgent:(NSString *)userAgent
-                                   rateLimiter:(SPTDataLoaderRateLimiter *)rateLimiter
-                                      resolver:(SPTDataLoaderResolver *)resolver
++ (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
+                                   rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                      resolver:(nullable SPTDataLoaderResolver *)resolver
                       customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses;
 
 /**


### PR DESCRIPTION
Adding nullability annotations to reflect what it says in the README under `Creating the SPTDataLoaderService` so clients don't get a warning for passing in nil.

> Note that you can provide all these as nils if you are so inclined, it may be for the best to use nils until you identify a need for these different configuration options.