### PR TITLE
Use rpath in install_name

### DIFF
--- a/SPTDataLoaderFramework.xcodeproj/project.pbxproj
+++ b/SPTDataLoaderFramework.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_DYLIB_INSTALL_NAME = "@rpath/SPTDataLoader.framework/SPTDataLoader";
 				LD_RUNPATH_SEARCH_PATHS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTDataLoader-iOS";
 				PRODUCT_NAME = SPTDataLoader;
@@ -896,6 +897,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_DYLIB_INSTALL_NAME = "@rpath/SPTDataLoader.framework/SPTDataLoader";
 				LD_RUNPATH_SEARCH_PATHS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTDataLoader-iOS";
 				PRODUCT_NAME = SPTDataLoader;


### PR DESCRIPTION
Using rpath in the install_name instructs the linker to search for a list of locations for the library.

Currently, if you try to use SPTDataLoader in another framework Foo.framework, clients of Foo.framework will run into `dyld: Library not loaded` on startup and crash.

https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html