### PR TITLE
Fix Race Conditions associated with new tasks for retries

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The task for performing the URL request on
  */
-@property (nonatomic, strong) NSURLSessionTask *task;
+@property (atomic, strong) NSURLSessionTask *task;
 /**
  * The request response handler to callback to
  */

--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -308,6 +308,9 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 didCompleteWithError:(nullable NSError *)error
 {
     SPTDataLoaderRequestTaskHandler *handler = [self handlerForTask:task];
+    if (handler == nil) {
+        return;
+    }
     handler.task = [self.session dataTaskWithRequest:handler.request.urlRequest];
     SPTDataLoaderResponse *response = [handler completeWithError:error];
     if (response == nil && !handler.cancelled) {

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -614,4 +614,23 @@
     XCTAssertNotNil(handler.task);
 }
 
+- (void)testDoNotRecreateTaskWhenNoHandlerAssociatedWithTask
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"https://localhost"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    request.maximumRetryCount = 10;
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+
+    SPTDataLoaderRequestTaskHandler *handler = self.service.handlers.firstObject;
+    NSURLSessionTaskMock *task = [NSURLSessionTaskMock new];
+    handler.task = task;
+
+    NSURLSessionTaskMock *otherTask = [NSURLSessionTaskMock new];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorDNSLookupFailed userInfo:nil];
+    [self.service URLSession:self.session task:otherTask didCompleteWithError:error];
+
+    XCTAssertEqualObjects(handler.task, task);
+}
+
 @end


### PR DESCRIPTION
* Issue 1: The task property was nonatomic while being accessed from different threads, this is a no no
* Issue 2: There are race conditions which can lead to handlers not being associated with a task, this is solved