### PR TITLE
Exposes a new method to handle cases where the NSURLSessionTask needs a new body stream due to redirects.

### DIFF
--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -223,6 +223,20 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
+                forRequest:(SPTDataLoaderRequest *)request
+{
+    if ([self.delegate respondsToSelector:@selector(dataLoader:needsNewBodyStream:forRequest:)]) {
+        [self executeDelegateBlock:^{
+            [self.delegate dataLoader:self
+                   needsNewBodyStream:completionHandler
+                           forRequest:request];
+        }];
+    } else {
+        completionHandler(request.bodyStream);
+    }
+}
+
 #pragma mark SPTDataLoaderCancellationTokenDelegate
 
 - (void)cancellationTokenDidCancel:(id<SPTDataLoaderCancellationToken>)cancellationToken

--- a/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/SPTDataLoader/SPTDataLoaderFactory.m
@@ -163,6 +163,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)needsNewBodyStream:(void (^)(NSInputStream * _Nonnull))completionHandler forRequest:(SPTDataLoaderRequest *)request
+{
+    id<SPTDataLoaderRequestResponseHandler> requestResponseHandler = nil;
+    @synchronized(self.requestToRequestResponseHandler) {
+        requestResponseHandler = [self.requestToRequestResponseHandler objectForKey:request];
+    }
+    [requestResponseHandler needsNewBodyStream:completionHandler forRequest:request];
+}
+
 #pragma mark SPTDataLoaderRequestResponseHandlerDelegate
 
 - (void)requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler

--- a/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -104,6 +104,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)receivedInitialResponse:(SPTDataLoaderResponse *)response;
 
+/**
+ * Called when a request using the @c bodyStream property encounters some sort of redirection that invalidates
+ * the initially provided input stream.
+ * @param completionHandler The completion handler that is to be called with the new input stream.
+ * @param request The request that needs a new input stream.
+ */
+- (void)needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
+                forRequest:(SPTDataLoaderRequest *)request;
+
 @optional
 
 /**

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -83,6 +83,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)start;
 
+/**
+ * Provides the task with a new body input stream.
+ */
+- (void)provideNewBodyStreamWithCompletion:(void (^)(NSInputStream * _Nonnull))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -193,6 +193,11 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
     self.executionBlock();
 }
 
+- (void)provideNewBodyStreamWithCompletion:(void (^)(NSInputStream * _Nonnull))completionHandler
+{
+    [self.requestResponseHandler needsNewBodyStream:completionHandler forRequest:self.request];
+}
+
 - (void)checkRateLimiterAndExecute
 {
     NSTimeInterval waitTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:self.request];

--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -393,6 +393,14 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
     completionHandler(newRequest);
 }
 
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+ needNewBodyStream:(void (^)(NSInputStream * _Nullable))completionHandler
+{
+    SPTDataLoaderRequestTaskHandler *handler = [self handlerForTask:task];
+    [handler provideNewBodyStreamWithCompletion:completionHandler];
+}
+
 #pragma mark NSObject
 
 - (void)dealloc

--- a/SPTDataLoaderTests/SPTDataLoaderDelegateMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderDelegateMock.h
@@ -25,11 +25,13 @@
 @interface SPTDataLoaderDelegateMock : NSObject <SPTDataLoaderDelegate>
 
 @property (nonatomic, assign) BOOL supportChunks;
+@property (nonatomic, assign) BOOL respondsToBodyStreamPrompts;
 @property (nonatomic, assign) NSUInteger numberOfCallsToSuccessfulResponse;
 @property (nonatomic, assign) NSUInteger numberOfCallsToErrorResponse;
 @property (nonatomic, assign) NSUInteger numberOfCallsToCancelledRequest;
 @property (nonatomic, assign) NSUInteger numberOfCallsToReceiveDataChunk;
 @property (nonatomic, assign) NSUInteger numberOfCallsToReceivedInitialResponse;
+@property (nonatomic, assign) NSUInteger numberOfCallsToNeedNewBodyStream;
 @property (nonatomic, strong) dispatch_block_t receivedSuccessfulBlock;
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderDelegateMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderDelegateMock.m
@@ -22,6 +22,15 @@
 
 @implementation SPTDataLoaderDelegateMock
 
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if (aSelector == @selector(dataLoader:needsNewBodyStream:forRequest:)) {
+        return self.respondsToBodyStreamPrompts;
+    } else {
+        return [super respondsToSelector:aSelector];
+    }
+}
+
 - (void)dataLoader:(SPTDataLoader *)dataLoader didReceiveSuccessfulResponse:(SPTDataLoaderResponse *)response
 {
     self.numberOfCallsToSuccessfulResponse++;
@@ -55,6 +64,11 @@ didReceiveDataChunk:(NSData *)data
 - (void)dataLoader:(SPTDataLoader *)dataLoader didReceiveInitialResponse:(SPTDataLoaderResponse *)response
 {
     self.numberOfCallsToReceivedInitialResponse++;
+}
+
+- (void)dataLoader:(SPTDataLoader *)dataLoader needsNewBodyStream:(void (^)(NSInputStream * _Nonnull))completionHandler forRequest:(SPTDataLoaderRequest *)request
+{
+    self.numberOfCallsToNeedNewBodyStream++;
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
@@ -37,7 +37,6 @@
 @end
 
 @interface SPTDataLoaderFactoryTest : XCTestCase
-
 @property (nonatomic, strong) SPTDataLoaderFactory *factory;
 
 @property (nonatomic, strong) SPTDataLoaderRequestResponseHandlerDelegateMock *delegate;
@@ -215,6 +214,16 @@
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
     [self.factory requestResponseHandler:requestResponseHandler cancelRequest:request];
     XCTAssertEqualObjects(request, self.delegate.lastRequestCancelled);
+}
+
+- (void)testRequestingNewBodyStream
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandler = [SPTDataLoaderRequestResponseHandlerMock new];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    [self.factory requestResponseHandler:requestResponseHandler performRequest:request];
+    [self.factory needsNewBodyStream:^(NSInputStream * _Nonnull _) {} forRequest:request];
+    
+    XCTAssertEqual(requestResponseHandler.numberOfNewBodyStreamCalls, 1u, @"The factory did not relay a prompt for delivering a new body stream to the correct handler");
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.h
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.h
@@ -31,6 +31,7 @@
 @property (nonatomic, assign, readonly) NSUInteger numberOfReceivedDataRequestCalls;
 @property (nonatomic, assign, readonly) NSUInteger numberOfSuccessfulDataResponseCalls;
 @property (nonatomic, assign, readonly) NSUInteger numberOfReceivedInitialResponseCalls;
+@property (nonatomic, assign, readonly) NSUInteger numberOfNewBodyStreamCalls;
 @property (nonatomic, strong, readonly) SPTDataLoaderResponse *lastReceivedResponse;
 @property (nonatomic, assign, readwrite, getter = isAuthorising) BOOL authorising;
 @property (nonatomic, strong, readwrite) dispatch_block_t failedResponseBlock;

--- a/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestResponseHandlerMock.m
@@ -27,6 +27,7 @@
 @property (nonatomic, assign, readwrite) NSUInteger numberOfReceivedDataRequestCalls;
 @property (nonatomic, assign, readwrite) NSUInteger numberOfSuccessfulDataResponseCalls;
 @property (nonatomic, assign, readwrite) NSUInteger numberOfReceivedInitialResponseCalls;
+@property (nonatomic, assign, readwrite) NSUInteger numberOfNewBodyStreamCalls;
 @property (nonatomic, strong, readwrite) SPTDataLoaderResponse *lastReceivedResponse;
 
 @end
@@ -74,6 +75,12 @@
 
 - (void)authoriseRequest:(SPTDataLoaderRequest *)request
 {
+}
+
+- (void)needsNewBodyStream:(void (^)(NSInputStream * _Nonnull))completionHandler
+                forRequest:(SPTDataLoaderRequest *)request
+{
+    self.numberOfNewBodyStreamCalls++;
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
@@ -106,6 +106,12 @@
     XCTAssertEqualWithAccuracy([self.rateLimiter earliestTimeUntilRequestCanBeExecuted:self.request], 59.0, 1.0, @"The retry-after header was not relayed to the rate limiter");
 }
 
+- (void)testRelayNewBodyStreamPrompt
+{
+    [self.handler provideNewBodyStreamWithCompletion:^(NSInputStream * _Nonnull _) {}];
+    XCTAssertEqual(self.requestResponseHandler.numberOfNewBodyStreamCalls, 1u);
+}
+
 - (void)testRetry
 {
     self.handler.retryCount = 10;

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -633,4 +633,14 @@
     XCTAssertEqualObjects(handler.task, task);
 }
 
+- (void)testProvidingNewBodyStream
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"https://localhost"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    [self.service URLSession:self.service.session task:self.session.lastDataTask needNewBodyStream:^(NSInputStream * _Nullable _) {}];
+    XCTAssertEqual(requestResponseHandlerMock.numberOfNewBodyStreamCalls, 1u, @"The service did not forward the prompt for a new body stream to the request response handler");
+}
+
 @end

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -79,6 +79,17 @@ didReceiveDataChunk:(NSData *)data
  */
 - (void)dataLoader:(SPTDataLoader *)dataLoader didReceiveInitialResponse:(SPTDataLoaderResponse *)response;
 
+/**
+ * Called when a data loader request using the @c bodyStream property encounters some sort of redirection that invalidates
+ * the initially provided input stream.
+ * @param dataLoader The data loader that needs a new input stream.
+ * @param completionHandler The completion handler that is to be called with the new input stream.
+ * @param request The request that needs a new input stream.
+ */
+- (void)dataLoader:(SPTDataLoader *)dataLoader
+needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
+        forRequest:(SPTDataLoaderRequest *)request;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is needed in certain cases when the new `bodyStream`-property is used on the `SPTDataLoaderRequest`.