### PR TITLE
Add HEAD request method support

### DIFF
--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -216,6 +216,7 @@ static NSString * const SPTDataLoaderRequestDeleteMethodString = @"DELETE";
 static NSString * const SPTDataLoaderRequestGetMethodString = @"GET";
 static NSString * const SPTDataLoaderRequestPostMethodString = @"POST";
 static NSString * const SPTDataLoaderRequestPutMethodString = @"PUT";
+static NSString * const SPTDataLoaderRequestHeadMethodString = @"HEAD";
 
 static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMethod requestMethod)
 {
@@ -224,6 +225,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
         case SPTDataLoaderRequestMethodGet: return SPTDataLoaderRequestGetMethodString;
         case SPTDataLoaderRequestMethodPost: return SPTDataLoaderRequestPostMethodString;
         case SPTDataLoaderRequestMethodPut: return SPTDataLoaderRequestPutMethodString;
+        case SPTDataLoaderRequestMethodHead: return SPTDataLoaderRequestHeadMethodString;
     }
 }
 

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -232,4 +232,10 @@
     XCTAssertNotNil(request.HTTPBodyStream, @"Should have created an HTTP body stream");
 }
 
+- (void)testHeadMethod
+{
+    self.request.method = SPTDataLoaderRequestMethodHead;
+    XCTAssertEqualObjects(self.request.urlRequest.HTTPMethod, @"HEAD");
+}
+
 @end

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -26,7 +26,8 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestMethod) {
     SPTDataLoaderRequestMethodGet,
     SPTDataLoaderRequestMethodPost,
     SPTDataLoaderRequestMethodPut,
-    SPTDataLoaderRequestMethodDelete
+    SPTDataLoaderRequestMethodDelete,
+    SPTDataLoaderRequestMethodHead
 };
 
 typedef NS_ENUM(NSInteger, SPTDataLoaderRequestErrorCode) {


### PR DESCRIPTION
* Adds ability for data loader to support HEAD requests
* Really useful for checking whether an item is available on a CDN without downloading the whole thing