### PR TITLE
Fix misuse of NSError in unit tests

### DIFF
--- a/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderFactoryTest.m
@@ -176,7 +176,7 @@
 {
     SPTDataLoaderAuthoriserMock *authoriser = [SPTDataLoaderAuthoriserMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    NSError *error = [NSError new];
+    NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
     [self.factory dataLoaderAuthoriser:authoriser didFailToAuthoriseRequest:request withError:error];
     XCTAssertEqual(request, self.delegate.lastRequestFailed, @"The factory did not relay the request authorisation failure to it's delegate");
 }

--- a/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderServiceTest.m
@@ -148,7 +148,7 @@
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
-    NSError *error = [NSError new];
+    NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
     [self.service requestResponseHandler:requestResponseHandlerMock failedToAuthoriseRequest:request error:error];
     XCTAssertEqual(requestResponseHandlerMock.numberOfFailedResponseCalls, 1u, @"The service did not call a failed response on a failed authorisation attempt");
 }


### PR DESCRIPTION
Calling `[NSError new]` triggers this log message:

> -[NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:.

@cerihughes 