### PR TITLE
Add background download task support

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */; };
 		05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */; };
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
+		487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */; };
+		48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */; };
+		48E7EEC62059288F00BB7CCC /* NSDataMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC52059288F00BB7CCC /* NSDataMock.m */; };
 		6994E68C1EE9F72600128CDE /* certs-google.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68B1EE9F49B00128CDE /* certs-google.bundle */; };
 		6994E68D1EE9F72800128CDE /* certs-spotify.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68A1EE9F49B00128CDE /* certs-spotify.bundle */; };
 		EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */; };
@@ -140,6 +143,12 @@
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
 		05EEB73D1C5C090B00A82266 /* NSBundleMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBundleMock.h; sourceTree = "<group>"; };
 		05EEB73E1C5C090B00A82266 /* NSBundleMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBundleMock.m; sourceTree = "<group>"; };
+		487FE3C520588E6C007141F9 /* NSURLSessionDownloadTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDownloadTaskMock.h; sourceTree = "<group>"; };
+		487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDownloadTaskMock.m; sourceTree = "<group>"; };
+		48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSFileManagerMock.m; sourceTree = "<group>"; };
+		48E7EEC220591A2E00BB7CCC /* NSFileManagerMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSFileManagerMock.h; sourceTree = "<group>"; };
+		48E7EEC42059288E00BB7CCC /* NSDataMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSDataMock.h; sourceTree = "<group>"; };
+		48E7EEC52059288F00BB7CCC /* NSDataMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDataMock.m; sourceTree = "<group>"; };
 		6994E68A1EE9F49B00128CDE /* certs-spotify.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "certs-spotify.bundle"; sourceTree = "<group>"; };
 		6994E68B1EE9F49B00128CDE /* certs-google.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "certs-google.bundle"; sourceTree = "<group>"; };
 		8247036C1BEA021C0027DE04 /* SPTDataLoaderCancellationTokenFactoryImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCancellationTokenFactoryImplementation.h; sourceTree = "<group>"; };
@@ -299,6 +308,10 @@
 				F7346A2C1CC2C71300B8AB41 /* NSURLAuthenticationChallengeMock.m */,
 				056A04C21A13DF4C00FA72AD /* NSURLSessionMock.h */,
 				056A04C31A13DF4C00FA72AD /* NSURLSessionMock.m */,
+				48E7EEC220591A2E00BB7CCC /* NSFileManagerMock.h */,
+				48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */,
+				48E7EEC42059288E00BB7CCC /* NSDataMock.h */,
+				48E7EEC52059288F00BB7CCC /* NSDataMock.m */,
 				0568B18C1A14A5FE00FEEBF8 /* SPTDataLoaderAuthoriserMock.h */,
 				0568B18D1A14A5FE00FEEBF8 /* SPTDataLoaderAuthoriserMock.m */,
 				059940411A14BA28006D6BE9 /* SPTDataLoaderRequestResponseHandlerMock.h */,
@@ -315,6 +328,8 @@
 				050F53861A2756570094F2BB /* SPTDataLoaderConsumptionObserverMock.m */,
 				EAC45A751C0F4633009AA9F9 /* NSURLSessionDataTaskMock.h */,
 				EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */,
+				487FE3C520588E6C007141F9 /* NSURLSessionDownloadTaskMock.h */,
+				487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */,
 				05EEB73D1C5C090B00A82266 /* NSBundleMock.h */,
 				05EEB73E1C5C090B00A82266 /* NSBundleMock.m */,
 				05A3BCB41D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.h */,
@@ -452,10 +467,12 @@
 			files = (
 				05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */,
 				059940431A14BA28006D6BE9 /* SPTDataLoaderRequestResponseHandlerMock.m in Sources */,
+				48E7EEC62059288F00BB7CCC /* NSDataMock.m in Sources */,
 				0599409F1A14F60F006D6BE9 /* SPTDataLoaderTest.m in Sources */,
 				05356F151A44B588003A7351 /* NSDictionaryHeaderSizeTest.m in Sources */,
 				0568B18E1A14A5FE00FEEBF8 /* SPTDataLoaderAuthoriserMock.m in Sources */,
 				05357B401C57D35D003A8AD0 /* SPTDataLoaderExponentialTimerTest.m in Sources */,
+				487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */,
 				EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */,
 				F7346A301CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.m in Sources */,
 				055AEE541A16262A00A490BF /* SPTDataLoaderRateLimiterTest.m in Sources */,
@@ -466,6 +483,7 @@
 				0504CB8D1A151B0600AD54EF /* SPTDataLoaderCancellationTokenFactoryImplementationTest.m in Sources */,
 				056A04BE1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m in Sources */,
 				059940A91A150C90006D6BE9 /* SPTDataLoaderResponseTest.m in Sources */,
+				48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */,
 				F7346A6E1CC2DEAA00B8AB41 /* SPTDataLoaderServerTrustPolicyTest.m in Sources */,
 				059940A71A150275006D6BE9 /* SPTDataLoaderRequestTest.m in Sources */,
 				0599409D1A14F32A006D6BE9 /* SPTDataLoaderRequestResponseHandlerDelegateMock.m in Sources */,
@@ -523,7 +541,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -533,7 +550,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/SPTDataLoader/SPTDataLoaderRequest.m
@@ -203,6 +203,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
     copy.cachePolicy = self.cachePolicy;
     copy.skipNSURLCache = self.skipNSURLCache;
     copy.method = self.method;
+    copy.backgroundPolicy = self.backgroundPolicy;
     copy.userInfo = self.userInfo;
     copy.timeout = self.timeout;
     copy.cancellationToken = self.cancellationToken;

--- a/SPTDataLoaderFramework.xcodeproj/xcshareddata/xcschemes/SPTDataLoader-OSX.xcscheme
+++ b/SPTDataLoaderFramework.xcodeproj/xcshareddata/xcschemes/SPTDataLoader-OSX.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/SPTDataLoaderTests/NSDataMock.h
+++ b/SPTDataLoaderTests/NSDataMock.h
@@ -20,12 +20,14 @@
  */
 #import <Foundation/Foundation.h>
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
+NS_ASSUME_NONNULL_BEGIN
 
-@interface NSURLSessionMock : NSURLSession
+@interface NSDataMock : NSObject
 
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
++ (nullable NSData *)dataWithContentsOfFile:(NSString *)path
+                                    options:(NSDataReadingOptions)readOptionsMask
+                                      error:(NSError * __autoreleasing * _Nullable)errorPtr;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SPTDataLoaderTests/NSDataMock.m
+++ b/SPTDataLoaderTests/NSDataMock.m
@@ -18,14 +18,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#import <Foundation/Foundation.h>
+#import "NSDataMock.h"
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
+@implementation NSDataMock
 
-@interface NSURLSessionMock : NSURLSession
-
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
++ (nullable NSData *)dataWithContentsOfFile:(NSString *)path
+                                    options:(NSDataReadingOptions)readOptionsMask
+                                      error:(NSError * __autoreleasing * _Nullable)errorPtr
+{
+    errorPtr = nil;
+    return [path dataUsingEncoding:NSUTF8StringEncoding];
+}
 
 @end

--- a/SPTDataLoaderTests/NSFileManagerMock.h
+++ b/SPTDataLoaderTests/NSFileManagerMock.h
@@ -20,12 +20,6 @@
  */
 #import <Foundation/Foundation.h>
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
-
-@interface NSURLSessionMock : NSURLSession
-
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
+@interface NSFileManagerMock : NSFileManager
 
 @end

--- a/SPTDataLoaderTests/NSFileManagerMock.m
+++ b/SPTDataLoaderTests/NSFileManagerMock.m
@@ -18,14 +18,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#import <Foundation/Foundation.h>
+#import "NSFileManagerMock.h"
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
+@implementation NSFileManagerMock
 
-@interface NSURLSessionMock : NSURLSession
+- (BOOL)moveItemAtPath:(NSString *)srcPath
+                toPath:(NSString *)dstPath
+                 error:(NSError * _Nullable __autoreleasing *)error
+{
+    return YES;
+}
 
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
+- (BOOL)removeItemAtPath:(NSString *)path
+                   error:(NSError * _Nullable __autoreleasing *)error
+{
+    return YES;
+}
 
 @end

--- a/SPTDataLoaderTests/NSURLSessionDownloadTaskMock.h
+++ b/SPTDataLoaderTests/NSURLSessionDownloadTaskMock.h
@@ -20,12 +20,17 @@
  */
 #import <Foundation/Foundation.h>
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
+@interface NSURLSessionDownloadTaskMock : NSURLSessionDownloadTask
 
-@interface NSURLSessionMock : NSURLSession
+@property (nonatomic, assign) NSUInteger numberOfCallsToResume;
+@property (nonatomic, assign) NSUInteger numberOfCallsToCancel;
 
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
+#pragma mark NSURLSessionTask
+
+@property (atomic, nullable, readonly, copy) NSURLRequest *currentRequest;
+@property (atomic, nullable, readonly, copy) NSURLResponse *response;
+
+@property (atomic, readonly) int64_t countOfBytesSent;
+@property (atomic, readonly) int64_t countOfBytesReceived;
 
 @end

--- a/SPTDataLoaderTests/NSURLSessionDownloadTaskMock.m
+++ b/SPTDataLoaderTests/NSURLSessionDownloadTaskMock.m
@@ -18,14 +18,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#import <Foundation/Foundation.h>
+#import "NSURLSessionDownloadTaskMock.h"
 
-@class NSURLSessionDataTaskMock;
-@class NSURLSessionDownloadTaskMock;
+@implementation NSURLSessionDownloadTaskMock
 
-@interface NSURLSessionMock : NSURLSession
+@synthesize countOfBytesSent;
+@synthesize countOfBytesReceived;
+@synthesize currentRequest;
+@synthesize response;
 
-@property (nonatomic, strong) NSURLSessionDataTaskMock *lastDataTask;
-@property (nonatomic, strong) NSURLSessionDownloadTaskMock *lastDownloadTask;
+- (void)resume
+{
+    self.numberOfCallsToResume++;
+}
+
+- (void)cancel
+{
+    self.numberOfCallsToCancel++;
+}
 
 @end

--- a/SPTDataLoaderTests/NSURLSessionMock.m
+++ b/SPTDataLoaderTests/NSURLSessionMock.m
@@ -20,6 +20,7 @@
  */
 #import "NSURLSessionMock.h"
 #import "NSURLSessionDataTaskMock.h"
+#import "NSURLSessionDownloadTaskMock.h"
 
 @implementation NSURLSessionMock
 
@@ -27,6 +28,12 @@
 {
     self.lastDataTask = [NSURLSessionDataTaskMock new];
     return self.lastDataTask;
+}
+
+- (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request
+{
+    self.lastDownloadTask = [NSURLSessionDownloadTaskMock new];
+    return self.lastDownloadTask;
 }
 
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTaskHandlerTest.m
@@ -204,4 +204,31 @@
     XCTAssertTrue(self.handler.cancelled);
 }
 
+- (void)testUpgradeToDownloadTaskAfterResponse
+{
+    self.request.backgroundPolicy = SPTDataLoaderRequestBackgroundPolicyOnDemand;
+    NSURLSessionResponseDisposition disposition = [self.handler receiveResponse:[NSURLResponse new]];
+    XCTAssertEqual(disposition, NSURLSessionResponseBecomeDownload,
+                   @"The handler did not return the correct response disposition (.BecomeDownload) given the background policy");
+}
+
+- (void)testKeepDataTaskAfterResponse
+{
+    self.request.backgroundPolicy = SPTDataLoaderRequestBackgroundPolicyDefault;
+    NSURLSessionResponseDisposition disposition = [self.handler receiveResponse:[NSURLResponse new]];
+    XCTAssertEqual(disposition, NSURLSessionResponseAllow,
+                   @"The handler did not return the correct response disposition (.Allow) given the background policy");
+}
+
+- (void)testReceiveDataWithNoInitialResponse
+{
+    NSString *dataString = @"TEST";
+    NSData *data = [dataString dataUsingEncoding:NSUTF8StringEncoding];
+    [self.handler receiveData:data];
+    [self.handler receiveData:data];
+    SPTDataLoaderResponse *response = [self.handler completeWithError:nil];
+    NSString *receivedString = [[NSString alloc] initWithData:(NSData * _Nonnull)response.body encoding:NSUTF8StringEncoding];
+    XCTAssertEqualObjects([dataString stringByAppendingString:dataString], receivedString);
+}
+
 @end

--- a/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
+++ b/SPTDataLoaderTests/SPTDataLoaderRequestTest.m
@@ -134,6 +134,7 @@
     self.request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
     self.request.skipNSURLCache = YES;
     self.request.method = SPTDataLoaderRequestMethodPost;
+    self.request.backgroundPolicy = SPTDataLoaderRequestBackgroundPolicyAlways;
     self.request.bodyStream = inputStream;
     SPTDataLoaderRequest *request = [self.request copy];
     XCTAssertEqual(request.maximumRetryCount, self.request.maximumRetryCount, @"The retry count was not copied correctly");
@@ -143,6 +144,7 @@
     XCTAssertEqual(request.cachePolicy, self.request.cachePolicy, @"The cache policy was not copied correctly");
     XCTAssertEqual(request.skipNSURLCache, self.request.skipNSURLCache, @"'skipNSURLCache' was not copied correctly");
     XCTAssertEqual(request.method, self.request.method, @"The method was not copied correctly");
+    XCTAssertEqual(request.backgroundPolicy, self.request.backgroundPolicy, @"The background policy was not copied correctly");
     XCTAssertEqual(request.bodyStream, self.request.bodyStream, @"The body stream was not copied correctly");
 }
 

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -35,6 +35,19 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestErrorCode) {
     SPTDataLoaderRequestErrorChunkedRequestWithoutChunkedDelegate
 };
 
+/**
+ How the request should be handled when the application enters the background
+
+ - SPTDataLoaderRequestBackgroundPolicyDefault: Allow the system to fail in-flight requests in the background
+ - SPTDataLoaderRequestBackgroundPolicyOnDemand: Hint to the system to upgrade this request to a background task
+ - SPTDataLoaderRequestBackgroundPolicyAlways: Use a background task but do not return response headers or status code
+ */
+typedef NS_ENUM(NSInteger, SPTDataLoaderRequestBackgroundPolicy) {
+    SPTDataLoaderRequestBackgroundPolicyDefault,
+    SPTDataLoaderRequestBackgroundPolicyOnDemand,
+    SPTDataLoaderRequestBackgroundPolicyAlways
+};
+
 extern NSString * const SPTDataLoaderRequestErrorDomain;
 
 /**
@@ -77,6 +90,10 @@ extern NSString * const SPTDataLoaderRequestErrorDomain;
  * @discussion The default request method is SPTDataLoaderRequestMethodGet
  */
 @property (nonatomic, assign) SPTDataLoaderRequestMethod method;
+/**
+ * Whether or not this request should use a background download task.
+ */
+@property (nonatomic, assign) SPTDataLoaderRequestBackgroundPolicy backgroundPolicy;
 /**
  * Any user information tied to this request
  */

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
                       customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses;
 
 /**
- * Class constructor
+ * Convenience class constructor
  * @param configuration Custom session configuration
  * @param rateLimiter The limiter for limiting requests per second on a per service basis
  * @param resolver The resolver for rerouting requests to different IP addresses
@@ -65,6 +65,33 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
                                        rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
                                           resolver:(nullable SPTDataLoaderResolver *)resolver;
+
+/**
+ * Class constructor with QoS
+ * @param userAgent The user agent to report as when making HTTP requests
+ * @param rateLimiter The limiter for limiting requests per second on a per service basis
+ * @param resolver The resolver for rerouting requests to different IP addresses
+ * @param customURLProtocolClasses Array of NSURLProtocol Class objects that you want
+ *                                 to use for this DataLoaderService. May be nil.
+ * @param qualityOfService The quality of service to use for the URL session queue
+ */
++ (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
+                                   rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                      resolver:(nullable SPTDataLoaderResolver *)resolver
+                      customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses
+                              qualityOfService:(NSQualityOfService)qualityOfService __OSX_AVAILABLE(10.10);
+
+/**
+ * Convenience class constructor with QoS
+ * @param configuration Custom session configuration
+ * @param rateLimiter The limiter for limiting requests per second on a per service basis
+ * @param resolver The resolver for rerouting requests to different IP addresses
+ * @param qualityOfService The quality of service to use for the URL session queue
+ */
++ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
+                                       rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                          resolver:(nullable SPTDataLoaderResolver *)resolver
+                                  qualityOfService:(NSQualityOfService)qualityOfService __OSX_AVAILABLE(10.10);
 
 /**
  * Creates a data loader factory


### PR DESCRIPTION
Rather than always using a data task to make requests, this change allows a "background policy" to be set on requests that determine when/if a background task is created:

- **Default**: Allow the system to fail in-flight requests in the background
- **OnDemand**: Upgrade data tasks to background tasks after receiving response headers
- **Always**: Use a background task at the start, don't return response headers/status code

Background tasks are important for long-running requests which may be killed by the operating system when the application loses foreground focus. It's possible to improve the reliability of such requests by using a download task instead.

This change is backwards compatible. The default policy (.Default) is to always use a data task as before.