### PR TITLE
Report downloaded size using Content-Length

### DIFF
--- a/SPTDataLoader/SPTDataLoaderService.m
+++ b/SPTDataLoader/SPTDataLoaderService.m
@@ -411,7 +411,13 @@ didCompleteWithError:(nullable NSError *)error
                     return;
                 }
                 int bytesSent = (int)task.countOfBytesSent;
-                int bytesReceived = (int)task.countOfBytesReceived;
+                int64_t bytesReceivedExpected = task.countOfBytesExpectedToReceive;
+                int bytesReceived;
+                if (bytesReceivedExpected == NSURLSessionTransferSizeUnknown) {
+                    bytesReceived = (int)task.countOfBytesReceived;
+                } else {
+                    bytesReceived = (int)bytesReceivedExpected;
+                }
                 
                 bytesSent += task.currentRequest.allHTTPHeaderFields.byteSizeOfHeaders;
                 if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {


### PR DESCRIPTION
Use the Content-Length field of the HTTP response header first.
If missing fallback to the number of bytes reported by the task.
This is useful when compressed data is returned by the server.
In that case, the task will report the uncompressed data instead
of the compressed one that was actually downloaded.