### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ brew install carthage
 ```
 You will also need to add `SPTDataLoader` to your `Cartfile`:
 ```
-github 'spotify/SPTDataLoader' ~> 1.1
+github "spotify/SPTDataLoader" ~> 1.1
 ```
 After that is all said and done, let Carthage pull in SPTDataLoader like so:
 ```shell


### PR DESCRIPTION
Fix Cartfile quotes type from single to double. Using single quotes makes Carthage will fail with error:
`Parse error: expected string after dependency type in line: github 'spotify/SPTDataLoader' ~> 1.1`