### PR TITLE
Refactors removing cancellation tokens avoiding mutation of array during iterating it

### DIFF
--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -81,13 +81,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     @synchronized(self.cancellationTokens) {
-        for (NSUInteger i = 0; i < self.cancellationTokens.count; /* incremented in body */) {
+        NSMutableIndexSet *indicesToRemove = [NSMutableIndexSet new];
+        for (NSUInteger i = 0; i < self.cancellationTokens.count; i++) {
             if ([self.cancellationTokens[i].objectToCancel isEqual:request]) {
-                [self.cancellationTokens removeObjectAtIndex:i];
-            } else {
-                ++i;
+                [indicesToRemove addIndex:i];
             }
         }
+        [self.cancellationTokens removeObjectsAtIndexes:indicesToRemove];
     }
 }
 


### PR DESCRIPTION
While refactored code is correct, mutation of collection while iterating it always raises a warning.
Proposed change is more CPU effective as removal of multiple array elements in one call avoids
multiple buffer copying and possible array storage deallocation.
Price for that effectives - need for storage of indices in NSMutableIndexSet.