### PR TITLE
Synchronize on currentRequests

### DIFF
--- a/SPTDataLoader/SPTDataLoader.m
+++ b/SPTDataLoader/SPTDataLoader.m
@@ -154,7 +154,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray<SPTDataLoaderRequest *> *)currentRequests
 {
-    return [self.requests copy];
+    @synchronized (self.requests) {
+        return [self.requests copy];
+    }
 }
 
 #pragma mark NSObject


### PR DESCRIPTION
Everywhere else we `@synchronize` on `self.requests`