### PR TITLE
Add per-request waitsForConnectivity flag

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */; };
 		05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */; };
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
+		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
 		487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */; };
 		48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */; };
 		48E7EEC62059288F00BB7CCC /* NSDataMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC52059288F00BB7CCC /* NSDataMock.m */; };
@@ -143,6 +145,11 @@
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
 		05EEB73D1C5C090B00A82266 /* NSBundleMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBundleMock.h; sourceTree = "<group>"; };
 		05EEB73E1C5C090B00A82266 /* NSBundleMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBundleMock.m; sourceTree = "<group>"; };
+		2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
+		2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
+		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
+		2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelectorMock.h; sourceTree = "<group>"; };
+		2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelectorMock.m; sourceTree = "<group>"; };
 		487FE3C520588E6C007141F9 /* NSURLSessionDownloadTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDownloadTaskMock.h; sourceTree = "<group>"; };
 		487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDownloadTaskMock.m; sourceTree = "<group>"; };
 		48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSFileManagerMock.m; sourceTree = "<group>"; };
@@ -232,6 +239,9 @@
 				F7794B001CB5904E0092AEC6 /* SPTDataLoaderServerTrustPolicy.m */,
 				F72EEAAC1CBDC4930072E073 /* SPTDataLoaderServerTrustPolicy+Private.h */,
 				050E06A51A10C68100A10A0E /* SPTDataLoaderService.m */,
+				2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */,
+				2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */,
+				2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -314,6 +324,8 @@
 				05EEB73E1C5C090B00A82266 /* NSBundleMock.m */,
 				05A3BCB41D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.h */,
 				05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */,
+				2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */,
+				2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -450,6 +462,7 @@
 				050E06BD1A10CFD700A10A0E /* SPTDataLoaderCancellationTokenImplementation.m in Sources */,
 				056E523F1A113A2B00E8716C /* SPTDataLoaderExponentialTimer.m in Sources */,
 				05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */,
+				2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05356F131A447295003A7351 /* NSDictionary+HeaderSize.m in Sources */,
 				050E06AF1A10CC6B00A10A0E /* SPTDataLoaderResponse.m in Sources */,
 				050E06A61A10C68100A10A0E /* SPTDataLoaderService.m in Sources */,
@@ -475,6 +488,7 @@
 				05356F151A44B588003A7351 /* NSDictionaryHeaderSizeTest.m in Sources */,
 				0568B18E1A14A5FE00FEEBF8 /* SPTDataLoaderAuthoriserMock.m in Sources */,
 				05357B401C57D35D003A8AD0 /* SPTDataLoaderExponentialTimerTest.m in Sources */,
+				2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */,
 				487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */,
 				EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */,
 				F7346A301CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.m in Sources */,

--- a/SPTDataLoaderFramework.xcodeproj/project.pbxproj
+++ b/SPTDataLoaderFramework.xcodeproj/project.pbxproj
@@ -103,6 +103,14 @@
 		05A638941C46B8A400061E37 /* SPTDataLoaderResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 056A04B71A13D10900FA72AD /* SPTDataLoaderResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05A638951C46B8A400061E37 /* SPTDataLoaderService.h in Headers */ = {isa = PBXBuildFile; fileRef = 056A04B81A13D10900FA72AD /* SPTDataLoaderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05A638961C46B8A400061E37 /* SPTDataLoaderExponentialTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 056A04B91A13D10900FA72AD /* SPTDataLoaderExponentialTimer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2DE3DABC2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */; };
+		2DE3DABD2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */; };
+		2DE3DABE2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */; };
+		2DE3DABF2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */; };
+		2DE3DAC02344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		2DE3DAC12344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		2DE3DAC22344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		2DE3DAC32344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		6992FD211F71DBD4003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6992FD221F71DC07003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6992FD231F71DC14003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -164,6 +172,9 @@
 		05A6380A1C46B53800061E37 /* SPTDataLoader.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTDataLoader.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CB0C431A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderRequestTaskHandler.h; sourceTree = "<group>"; };
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
+		2DE3DAB92344E0F70022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
+		2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
+		2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
 		6992FD1A1F71DB8B003E1E4F /* SPTDataLoaderServerTrustPolicy+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderServerTrustPolicy+Private.h"; sourceTree = "<group>"; };
 		6992FD1B1F71DB8C003E1E4F /* SPTDataLoaderImplementation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderImplementation+Private.h"; sourceTree = "<group>"; };
 		6992FD1C1F71DB8C003E1E4F /* SPTDataLoaderCancellationTokenFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCancellationTokenFactory.h; sourceTree = "<group>"; };
@@ -268,6 +279,9 @@
 				F7346A371CC2CF8200B8AB41 /* SPTDataLoaderServerTrustPolicy.m */,
 				6992FD1A1F71DB8B003E1E4F /* SPTDataLoaderServerTrustPolicy+Private.h */,
 				050E06A51A10C68100A10A0E /* SPTDataLoaderService.m */,
+				2DE3DAB92344E0F70022642E /* SPTDataLoaderService+Private.h */,
+				2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */,
+				2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -332,6 +346,7 @@
 				6992FD2D1F71DEE9003E1E4F /* SPTDataLoader.h in Headers */,
 				05A638181C46B55000061E37 /* SPTDataLoaderCancellationToken.h in Headers */,
 				05A6381A1C46B55000061E37 /* SPTDataLoaderAuthoriser.h in Headers */,
+				2DE3DABC2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */,
 				05A6381B1C46B55000061E37 /* SPTDataLoaderConsumptionObserver.h in Headers */,
 				05A6381D1C46B55000061E37 /* SPTDataLoaderDelegate.h in Headers */,
 				05A6381E1C46B55000061E37 /* SPTDataLoaderFactory.h in Headers */,
@@ -353,6 +368,7 @@
 				6992FD2E1F71DEEE003E1E4F /* SPTDataLoader.h in Headers */,
 				05A638561C46B85300061E37 /* SPTDataLoaderCancellationToken.h in Headers */,
 				05A638581C46B85300061E37 /* SPTDataLoaderAuthoriser.h in Headers */,
+				2DE3DABD2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */,
 				05A638591C46B85300061E37 /* SPTDataLoaderConsumptionObserver.h in Headers */,
 				05A6385B1C46B85300061E37 /* SPTDataLoaderDelegate.h in Headers */,
 				05A6385C1C46B85300061E37 /* SPTDataLoaderFactory.h in Headers */,
@@ -374,6 +390,7 @@
 				6992FD2F1F71DEF8003E1E4F /* SPTDataLoader.h in Headers */,
 				05A638701C46B87700061E37 /* SPTDataLoaderCancellationToken.h in Headers */,
 				05A638721C46B87800061E37 /* SPTDataLoaderAuthoriser.h in Headers */,
+				2DE3DABE2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */,
 				05A638731C46B87800061E37 /* SPTDataLoaderConsumptionObserver.h in Headers */,
 				05A638751C46B87800061E37 /* SPTDataLoaderDelegate.h in Headers */,
 				05A638761C46B87800061E37 /* SPTDataLoaderFactory.h in Headers */,
@@ -395,6 +412,7 @@
 				6992FD301F71DEFE003E1E4F /* SPTDataLoader.h in Headers */,
 				05A6388A1C46B8A400061E37 /* SPTDataLoaderCancellationToken.h in Headers */,
 				05A6388C1C46B8A400061E37 /* SPTDataLoaderAuthoriser.h in Headers */,
+				2DE3DABF2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h in Headers */,
 				05A6388D1C46B8A400061E37 /* SPTDataLoaderConsumptionObserver.h in Headers */,
 				05A6388F1C46B8A400061E37 /* SPTDataLoaderDelegate.h in Headers */,
 				05A638901C46B8A400061E37 /* SPTDataLoaderFactory.h in Headers */,
@@ -567,6 +585,7 @@
 				058CD0001C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.m in Sources */,
 				05A6383C1C46B82700061E37 /* NSDictionary+HeaderSize.m in Sources */,
 				05A6383D1C46B82700061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
+				2DE3DAC02344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6383F1C46B82700061E37 /* SPTDataLoader.m in Sources */,
 				05A638401C46B82700061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A638411C46B82700061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
@@ -588,6 +607,7 @@
 				058CD0011C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.m in Sources */,
 				05A638491C46B84B00061E37 /* NSDictionary+HeaderSize.m in Sources */,
 				05A6384A1C46B84B00061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
+				2DE3DAC12344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6384C1C46B84B00061E37 /* SPTDataLoader.m in Sources */,
 				05A6384D1C46B84B00061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A6384E1C46B84B00061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
@@ -609,6 +629,7 @@
 				058CD0021C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.m in Sources */,
 				05A638631C46B87100061E37 /* NSDictionary+HeaderSize.m in Sources */,
 				05A638641C46B87100061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
+				2DE3DAC22344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A638661C46B87100061E37 /* SPTDataLoader.m in Sources */,
 				05A638671C46B87100061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A638681C46B87100061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
@@ -630,6 +651,7 @@
 				058CD0031C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.m in Sources */,
 				05A638261C46B7F800061E37 /* NSDictionary+HeaderSize.m in Sources */,
 				05A638281C46B7F800061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
+				2DE3DAC32344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6382B1C46B7F800061E37 /* SPTDataLoader.m in Sources */,
 				05A6382D1C46B7F800061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A6382F1C46B7F800061E37 /* SPTDataLoaderRateLimiter.m in Sources */,

--- a/Sources/SPTDataLoader.m
+++ b/Sources/SPTDataLoader.m
@@ -246,6 +246,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)requestIsWaitingForConnectivity:(SPTDataLoaderRequest *)request
+{
+    if ([self.delegate respondsToSelector:@selector(dataLoader:requestIsWaitingForConnectivity:)]) {
+        [self executeDelegateBlock:^{
+            [self.delegate dataLoader:self requestIsWaitingForConnectivity:request];
+        }];
+    }
+}
+
 - (void)needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
                 forRequest:(SPTDataLoaderRequest *)request
 {

--- a/Sources/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoaderFactory.m
@@ -31,7 +31,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SPTDataLoaderFactory () <SPTDataLoaderRequestResponseHandlerDelegate, SPTDataLoaderAuthoriserDelegate>
+@interface SPTDataLoaderFactory () <SPTDataLoaderRequestResponseHandlerDelegate, SPTDataLoaderAuthoriserDelegate, SPTDataLoaderRequestResponseHandler>
 
 @property (nonatomic, strong) NSMapTable<SPTDataLoaderRequest *, id<SPTDataLoaderRequestResponseHandler>> *requestToRequestResponseHandler;
 @property (nonatomic, strong, readwrite) dispatch_queue_t requestTimeoutQueue;
@@ -140,6 +140,15 @@ NS_ASSUME_NONNULL_BEGIN
         requestResponseHandler = [self.requestToRequestResponseHandler objectForKey:response.request];
     }
     [requestResponseHandler receivedInitialResponse:response];
+}
+
+- (void)requestIsWaitingForConnectivity:(nonnull SPTDataLoaderRequest *)request
+{
+    id<SPTDataLoaderRequestResponseHandler> requestResponseHandler = nil;
+    @synchronized(self.requestToRequestResponseHandler) {
+        requestResponseHandler = [self.requestToRequestResponseHandler objectForKey:request];
+    }
+    [requestResponseHandler requestIsWaitingForConnectivity:request];
 }
 
 - (BOOL)shouldAuthoriseRequest:(SPTDataLoaderRequest *)request

--- a/Sources/SPTDataLoaderRequest.m
+++ b/Sources/SPTDataLoaderRequest.m
@@ -194,6 +194,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
     __typeof(self) copy = [[self.class alloc] initWithURL:self.URL
                                          sourceIdentifier:self.sourceIdentifier
                                          uniqueIdentifier:self.uniqueIdentifier];
+    copy.waitsForConnectivity = self.waitsForConnectivity;
     copy.maximumRetryCount = self.maximumRetryCount;
     copy.body = [self.body copy];
     @synchronized(self.mutableHeaders) {

--- a/Sources/SPTDataLoaderRequestResponseHandler.h
+++ b/Sources/SPTDataLoaderRequestResponseHandler.h
@@ -102,7 +102,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param response The response containing the initial information (such as headers)
  */
 - (void)receivedInitialResponse:(SPTDataLoaderResponse *)response;
-
+/**
+ Called when a request with waitsForConnectivity enters the waiting state
+ @param request The request that is waiting
+ */
 - (void)requestIsWaitingForConnectivity:(SPTDataLoaderRequest *)request;
 
 /**

--- a/Sources/SPTDataLoaderRequestResponseHandler.h
+++ b/Sources/SPTDataLoaderRequestResponseHandler.h
@@ -103,6 +103,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)receivedInitialResponse:(SPTDataLoaderResponse *)response;
 
+- (void)requestIsWaitingForConnectivity:(SPTDataLoaderRequest *)request;
+
 /**
  Called when a request using the @c bodyStream property encounters some sort of redirection that invalidates
  the initially provided input stream.

--- a/Sources/SPTDataLoaderRequestTaskHandler.h
+++ b/Sources/SPTDataLoaderRequestTaskHandler.h
@@ -88,6 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)provideNewBodyStreamWithCompletion:(void (^)(NSInputStream * _Nonnull))completionHandler;
 
+- (void)noteWaitingForConnectivity;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderRequestTaskHandler.h
+++ b/Sources/SPTDataLoaderRequestTaskHandler.h
@@ -74,6 +74,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error;
 /**
+ Called when a request with waitsForConnectivity enters the waiting state
+*/
+- (void)noteWaitingForConnectivity;
+/**
  Gets called whenever the original request was redirected.
  Returns YES to allow redirect, NO to block it.
  */
@@ -87,8 +91,6 @@ NS_ASSUME_NONNULL_BEGIN
  Provides the task with a new body input stream.
  */
 - (void)provideNewBodyStreamWithCompletion:(void (^)(NSInputStream * _Nonnull))completionHandler;
-
-- (void)noteWaitingForConnectivity;
 
 @end
 

--- a/Sources/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoaderRequestTaskHandler.m
@@ -206,6 +206,11 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
     [self.requestResponseHandler needsNewBodyStream:completionHandler forRequest:self.request];
 }
 
+- (void)noteWaitingForConnectivity
+{
+    [self.requestResponseHandler requestIsWaitingForConnectivity:self.request];
+}
+
 - (void)checkRateLimiterAndExecute
 {
     NSTimeInterval waitTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:self.request];

--- a/Sources/SPTDataLoaderService+Private.h
+++ b/Sources/SPTDataLoaderService+Private.h
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2015-2019 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <SPTDataLoader/SPTDataLoaderService.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SPTDataLoaderServiceSessionSelector;
+
+
+@interface SPTDataLoaderService ()
+
+@property (nonatomic, strong) id<SPTDataLoaderServiceSessionSelector> sessionSelector;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderServiceSessionSelector.h
+++ b/Sources/SPTDataLoaderServiceSessionSelector.h
@@ -1,0 +1,50 @@
+/*
+ Copyright (c) 2015-2019 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SPTDataLoaderRequest;
+
+
+/**
+ A @c SPTDataLoaderServiceSessionSelector is responsible for selecting the most appropriate @c NSURLSession for a
+ given request.
+ */
+@protocol SPTDataLoaderServiceSessionSelector <NSObject>
+
+- (NSURLSession *)URLSessionForRequest:(SPTDataLoaderRequest *)request;
+
+@end
+
+/**
+ Production implementation of @c SPTDataLoaderServiceSessionSelector .
+ */
+@interface SPTDataLoaderServiceDefaultSessionSelector: NSObject <SPTDataLoaderServiceSessionSelector>
+
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+                             delegate:(id<NSURLSessionDelegate>)delegate
+                        delegateQueue:(NSOperationQueue *)delegateQueue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoaderServiceSessionSelector.m
@@ -1,0 +1,97 @@
+/*
+ Copyright (c) 2015-2019 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderServiceSessionSelector.h"
+#import <SPTDataLoader/SPTDataLoaderRequest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderServiceDefaultSessionSelector ()
+
+@property (nonatomic, strong, readonly) NSURLSessionConfiguration *configuration;
+@property (nonatomic, weak, readonly) id<NSURLSessionDelegate> delegate;
+@property (nonatomic, strong, readonly) NSOperationQueue *delegateQueue;
+
+@end
+
+
+@implementation SPTDataLoaderServiceDefaultSessionSelector
+{
+    NSURLSession *_nonWaitingSession;
+    NSURLSession *_waitingSession;
+}
+
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+                             delegate:(id<NSURLSessionDelegate>)delegate
+                        delegateQueue:(NSOperationQueue *)delegateQueue
+{
+    self = [super init];
+
+    if (self != nil) {
+        _configuration = [configuration copy];
+    }
+
+    return self;
+}
+
+- (NSURLSession *)URLSessionForRequest:(SPTDataLoaderRequest *)request
+{
+    if (request.waitsForConnectivity) {
+        return self.waitingSession;
+    } else {
+        return self.nonWaitingSession;
+    }
+}
+
+- (NSURLSession *)waitingSession
+{
+    if (_waitingSession == nil) {
+        _waitingSession = [self createWaitingSession];
+    }
+    return _waitingSession;
+}
+
+- (NSURLSession *)nonWaitingSession
+{
+    if (_nonWaitingSession == nil) {
+        _nonWaitingSession = [NSURLSession sessionWithConfiguration:self.configuration
+                                                           delegate:self.delegate
+                                                      delegateQueue:self.delegateQueue];
+    }
+    return _nonWaitingSession;
+}
+
+- (NSURLSession *)createWaitingSession
+{
+    if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+        NSURLSessionConfiguration *configuration = [self.configuration copy];
+        configuration.waitsForConnectivity = YES;
+        return [NSURLSession sessionWithConfiguration:configuration
+                                             delegate:self.delegate
+                                        delegateQueue:self.delegateQueue];
+    } else {
+        return self.nonWaitingSession;
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoaderRequestResponseHandlerMock.m
+++ b/Tests/SPTDataLoaderRequestResponseHandlerMock.m
@@ -77,6 +77,10 @@
 {
 }
 
+- (void)requestIsWaitingForConnectivity:(nonnull SPTDataLoaderRequest *)request
+{
+}
+
 - (void)needsNewBodyStream:(void (^)(NSInputStream * _Nonnull))completionHandler
                 forRequest:(SPTDataLoaderRequest *)request
 {

--- a/Tests/SPTDataLoaderServiceSessionSelectorMock.h
+++ b/Tests/SPTDataLoaderServiceSessionSelectorMock.h
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2015-2019 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderServiceSessionSelector.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderServiceSessionSelectorMock : NSObject <SPTDataLoaderServiceSessionSelector>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithResolver:(NSURLSession *(^)(SPTDataLoaderRequest *))resolver NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoaderServiceSessionSelectorMock.m
+++ b/Tests/SPTDataLoaderServiceSessionSelectorMock.m
@@ -1,0 +1,50 @@
+/*
+ Copyright (c) 2015-2019 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderServiceSessionSelectorMock.h"
+#import "NSURLSessionMock.h"
+
+@interface SPTDataLoaderServiceSessionSelectorMock ()
+
+@property (nonatomic, strong, readonly) NSURLSession *(^resolve)(SPTDataLoaderRequest *);
+
+@end
+
+
+@implementation SPTDataLoaderServiceSessionSelectorMock
+
+- (instancetype)initWithResolver:(NSURLSession *(^)(SPTDataLoaderRequest *))resolver
+{
+    self = [super init];
+
+    if (self != nil) {
+        _resolve = resolver;
+    }
+
+    return self;
+}
+
+- (NSURLSession *)URLSessionForRequest:(SPTDataLoaderRequest *)request
+{
+    return self.resolve(request);
+}
+
+@end

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -90,7 +90,11 @@ didReceiveDataChunk:(NSData *)data
 needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
         forRequest:(SPTDataLoaderRequest *)request;
 
-
+/**
+ Called when a data loader request with the @c waitsForConnectivity property set begins waiting for connectivity.
+ @param dataLoader The data loader managing the request.
+ @param request The request that began waiting.
+ */
 - (void)dataLoader:(SPTDataLoader *)dataLoader
 requestIsWaitingForConnectivity:(SPTDataLoaderRequest *)request;
 

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -90,6 +90,10 @@ didReceiveDataChunk:(NSData *)data
 needsNewBodyStream:(void (^)(NSInputStream *))completionHandler
         forRequest:(SPTDataLoaderRequest *)request;
 
+
+- (void)dataLoader:(SPTDataLoader *)dataLoader
+requestIsWaitingForConnectivity:(SPTDataLoaderRequest *)request;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestBackgroundPolicy) {
  A Boolean value that indicates whether the session should wait for connectivity to become
  available, or fail immediately.
  @discussion See documentation for NSURLSession.waitsForConnectivity for detailed semantics.
- This flag is ignored in iOS 10, macOS 10.12, tvOS 10, watchOS 4 or earlier.
+ This flag is ignored on OS versions earlier than iOS 11, macOS 10.13, tvOS 11, and watchOS 4.
  */
 @property (nonatomic, assign) BOOL waitsForConnectivity;
 /**

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -61,6 +61,13 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestBackgroundPolicy) {
  */
 @property (nonatomic, strong) NSURL *URL;
 /**
+ A Boolean value that indicates whether the session should wait for connectivity to become
+ available, or fail immediately.
+ @discussion See documentation for NSURLSession.waitsForConnectivity for detailed semantics.
+ This flag is ignored in iOS 10, macOS 10.12, tvOS 10, watchOS 4 or earlier.
+ */
+@property (nonatomic, assign) BOOL waitsForConnectivity;
+/**
  The number of times to retry this request in the event of a failure
  @discussion The default is 0
  */


### PR DESCRIPTION
* Adds `waitForConnectivity` flag to `SPTDataLoaderRequest`
* Adds a mechanism to support multiple `NSURLSession`s and select between them for each request
* Routes `waitingForConnectivity` notification through the various layers

Missing:
- ~[ ] Tests~ — not effectively testable
- [x] Documentation
- [x] The request sent to the delegate is currently the internal copy of the request made by SPTDataLoader for reasons, this is bad.