### PR TITLE
Turn SPTDataLoaderResponseHTTPStatusCode back to a regular enum

### DIFF
--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -22,10 +22,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const SPTDataLoaderResponseErrorDomain;
-
 /// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-typedef NS_ERROR_ENUM(SPTDataLoaderResponseErrorDomain, SPTDataLoaderResponseHTTPStatusCode) {
+typedef NS_ENUM(NSInteger, SPTDataLoaderResponseHTTPStatusCode) {
     SPTDataLoaderResponseHTTPStatusCodeInvalid = 0,
     // Informational
     SPTDataLoaderResponseHTTPStatusCodeContinue = 100,
@@ -76,6 +74,8 @@ typedef NS_ERROR_ENUM(SPTDataLoaderResponseErrorDomain, SPTDataLoaderResponseHTT
 };
 
 @class SPTDataLoaderRequest;
+
+extern NSString * const SPTDataLoaderResponseErrorDomain;
 
 /**
  An object representing the response from the backend


### PR DESCRIPTION
In #174 I changed this from `NS_ENUM` to `NS_ERROR_ENUM` for modern style and better bridging to Swift. However, it turns out that `SPTDataLoaderResponseHTTPStatusCode` is used _both_ as an `NSError` code and in other contexts, which is terribad and breaks things.

See https://github.com/spotify/SPTDataLoader/commit/5f62f06b955dac2cd5ccb4dea27be73dad5d39af#r35424354

@dmakarov @gitrema 