### PR TITLE
Specify SDK parameter when building framework

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -101,7 +101,7 @@ xcb "Run tests for iOS" test \
   -enableCodeCoverage YES \
   -destination "platform=iOS Simulator,name=iPhone 8,OS=$LATEST_IOS_SDK"
 
-LATEST_TVOS_SDK="$(/usr/libexec/PlistBuddy -c "Print :Version" "$(xcrun --show-sdk-path --sdk iphonesimulator)/SDKSettings.plist")"
+LATEST_TVOS_SDK="$(/usr/libexec/PlistBuddy -c "Print :Version" "$(xcrun --show-sdk-path --sdk appletvsimulator)/SDKSettings.plist")"
 xcb "Run tests for tvOS" test \
   -scheme "SPTDataLoader" \
   -enableCodeCoverage YES \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -63,15 +63,19 @@ build_library appletvsimulator
 #
 
 build_framework() {
-  xcb "Build Framework [$1]" \
+  xcb "Build Framework [$1] [$2]" \
     build -scheme "$1" \
+    -sdk "$2" \
     -configuration Release
 }
 
-build_framework SPTDataLoader-iOS
-build_framework SPTDataLoader-OSX
-build_framework SPTDataLoader-TV
-build_framework SPTDataLoader-Watch
+build_framework SPTDataLoader-iOS iphoneos
+build_framework SPTDataLoader-iOS iphonesimulator
+build_framework SPTDataLoader-OSX macosx
+build_framework SPTDataLoader-Watch watchos
+build_framework SPTDataLoader-Watch watchsimulator
+build_framework SPTDataLoader-TV appletvos
+build_framework SPTDataLoader-TV appletvsimulator
 
 #
 # BUILD DEMO APP


### PR DESCRIPTION
This should fix building on CI, since it seems that the image has been updated by GitHub and builds started failing with:
```
xcodebuild: error: Failed to build workspace SPTDataLoader with scheme SPTDataLoader-iOS.
Reason: The run destination My Mac is not valid for Running the scheme 'SPTDataLoader-iOS'.
Recovery suggestion: My Mac doesn’t support any of SPTDataLoader.framework’s architectures. You can add My Mac’s x86_64 architecture to SPTDataLoader.framework’s Architectures build setting.
```