### PR TITLE
Pin Xcode version to 11.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,4 +10,5 @@ jobs:
     - name: Build and Test
       run: ci/run.sh
       env:
+        DEVELOPER_DIR: /Applications/Xcode_11.1.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,4 +13,5 @@ jobs:
     - name: Build and Test
       run: ci/run.sh
       env:
+        DEVELOPER_DIR: /Applications/Xcode_11.1.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I couldn't find a way to see which version we're currently using, but each macOS image has multiple Xcode versions installed. Since we're also targeting `macOS-latest`, if the image changes, also the Xcode version might change and our builds could suddenly break (like in #183).