### PR TITLE
Add resolvedURL property to response object

### DIFF
--- a/Sources/SPTDataLoaderResponse.m
+++ b/Sources/SPTDataLoaderResponse.m
@@ -30,7 +30,6 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 @interface SPTDataLoaderResponse ()
 
-@property (nonatomic, strong, readonly, nullable) NSURLResponse *response;
 @property (nonatomic, strong, readwrite) NSDictionary<NSString *, NSString *> *responseHeaders;
 @property (nonatomic, strong, readwrite) NSError *error;
 @property (nonatomic, strong, readwrite) NSData *body;
@@ -52,7 +51,6 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
     self = [super init];
     if (self) {
         _request = request;
-        _response = response;
 
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
@@ -62,6 +60,7 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
                                              code:httpResponse.statusCode
                                          userInfo:nil];
             }
+            _resolvedURL = httpResponse.URL;
             _responseHeaders = httpResponse.allHeaderFields;
             _statusCode = httpResponse.statusCode;
         }
@@ -184,7 +183,7 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p URL = \"%@\"; status-code = %ld; headers = %@>", self.class, (void *)self, self.response.URL, (long)self.statusCode, self.responseHeaders];
+    return [NSString stringWithFormat:@"<%@: %p URL = \"%@\"; status-code = %ld; headers = %@>", self.class, (void *)self, self.resolvedURL, (long)self.statusCode, self.responseHeaders];
 }
 
 

--- a/Tests/SPTDataLoaderResponseTest.m
+++ b/Tests/SPTDataLoaderResponseTest.m
@@ -195,5 +195,22 @@
                   @"The description should contain the headers code of the response");
 }
 
+- (void)testResolvedURLComesFromResponse
+{
+    NSURL *requestURL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
+    NSURL *responseURL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/redirected"];
+
+    self.request = [SPTDataLoaderRequest requestWithURL:requestURL
+                                       sourceIdentifier:nil];
+    self.urlResponse = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                   statusCode:SPTDataLoaderResponseHTTPStatusCodeInvalid
+                                                  HTTPVersion:@"1.1"
+                                                 headerFields:nil];
+
+    self.response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:self.request response:self.urlResponse];
+
+    XCTAssertEqual(self.response.resolvedURL, responseURL);
+    XCTAssertNotEqual(self.response.resolvedURL, self.request.URL);
+}
 
 @end

--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -96,6 +96,10 @@ extern NSString * const SPTDataLoaderResponseErrorDomain;
  */
 @property (nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> *responseHeaders;
 /**
+ The URL that provided the response (after any redirects).
+ */
+@property (nonatomic, strong, readonly, nullable) NSURL *resolvedURL;
+/**
  The date at which the request that generated the response can be retried
  @warning Can be nil if no retry-after is given in the response headers
  @discussion This should only show up if the response is an error. It can still show up in a successful response, but


### PR DESCRIPTION
After following redirects, the value in `-[NSURLResponse URL]` may be different from that of the request. There are instances where we want to capture this.