### PR TITLE
Fix issue that was making the DataLoaderRateLimiter delaying requests unnecessarily if the system clock was moved backwards

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
 		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
+		430D3C82249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
+		430D3C87249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */; };
+		430D3C89249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */; };
 		487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */; };
 		48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */; };
 		48E7EEC62059288F00BB7CCC /* NSDataMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC52059288F00BB7CCC /* NSDataMock.m */; };
@@ -150,6 +153,13 @@
 		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
 		2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelectorMock.h; sourceTree = "<group>"; };
 		2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelectorMock.m; sourceTree = "<group>"; };
+		430D3C80249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderImplementation.h; sourceTree = "<group>"; };
+		430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementation.m; sourceTree = "<group>"; };
+		430D3C83249CD7C300791FD3 /* SPTDataLoaderTimeProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProvider.h; sourceTree = "<group>"; };
+		430D3C84249CDA9400791FD3 /* SPTDataLoaderRateLimiter+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderRateLimiter+Private.h"; sourceTree = "<group>"; };
+		430D3C85249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderMock.h; sourceTree = "<group>"; };
+		430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderMock.m; sourceTree = "<group>"; };
+		430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementationTest.m; sourceTree = "<group>"; };
 		487FE3C520588E6C007141F9 /* NSURLSessionDownloadTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDownloadTaskMock.h; sourceTree = "<group>"; };
 		487FE3C620588E6D007141F9 /* NSURLSessionDownloadTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDownloadTaskMock.m; sourceTree = "<group>"; };
 		48E7EEC120591A2E00BB7CCC /* NSFileManagerMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSFileManagerMock.m; sourceTree = "<group>"; };
@@ -226,6 +236,7 @@
 				050E06BE1A10F26800A10A0E /* SPTDataLoaderFactory+Private.h */,
 				050E06B31A10CDE900A10A0E /* SPTDataLoaderImplementation+Private.h */,
 				052FB1611A125E4D00AFE80E /* SPTDataLoaderRateLimiter.m */,
+				430D3C84249CDA9400791FD3 /* SPTDataLoaderRateLimiter+Private.h */,
 				050E06AB1A10CC1300A10A0E /* SPTDataLoaderRequest.m */,
 				056E52381A11275700E8716C /* SPTDataLoaderRequest+Private.h */,
 				056E523C1A11348800E8716C /* SPTDataLoaderRequestResponseHandler.h */,
@@ -242,6 +253,9 @@
 				2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */,
 				2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */,
 				2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */,
+				430D3C83249CD7C300791FD3 /* SPTDataLoaderTimeProvider.h */,
+				430D3C80249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.h */,
+				430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -249,22 +263,23 @@
 		050E06991A10C62100A10A0E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				050E069A1A10C62100A10A0E /* Supporting Files */,
-				056A04BD1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m */,
-				F7346A6D1CC2DEAA00B8AB41 /* SPTDataLoaderServerTrustPolicyTest.m */,
-				059940961A14E7F1006D6BE9 /* SPTDataLoaderFactoryTest.m */,
-				0599409E1A14F60F006D6BE9 /* SPTDataLoaderTest.m */,
-				059940A61A150275006D6BE9 /* SPTDataLoaderRequestTest.m */,
-				059940A81A150C90006D6BE9 /* SPTDataLoaderResponseTest.m */,
+				05356F141A44B588003A7351 /* NSDictionaryHeaderSizeTest.m */,
 				0504CB8C1A151B0600AD54EF /* SPTDataLoaderCancellationTokenFactoryImplementationTest.m */,
 				0504CB8E1A151B6D00AD54EF /* SPTDataLoaderCancellationTokenImplementationTest.m */,
-				0504CB901A151C8600AD54EF /* SPTDataLoaderRequestTaskHandlerTest.m */,
-				055AEE531A16262A00A490BF /* SPTDataLoaderRateLimiterTest.m */,
-				055AEE551A162C5E00A490BF /* SPTDataLoaderResolverTest.m */,
-				055AEE571A162F0200A490BF /* SPTDataLoaderResolverAddressTest.m */,
-				05356F141A44B588003A7351 /* NSDictionaryHeaderSizeTest.m */,
 				05357B3F1C57D35D003A8AD0 /* SPTDataLoaderExponentialTimerTest.m */,
+				059940961A14E7F1006D6BE9 /* SPTDataLoaderFactoryTest.m */,
+				055AEE531A16262A00A490BF /* SPTDataLoaderRateLimiterTest.m */,
+				0504CB901A151C8600AD54EF /* SPTDataLoaderRequestTaskHandlerTest.m */,
+				059940A61A150275006D6BE9 /* SPTDataLoaderRequestTest.m */,
+				055AEE571A162F0200A490BF /* SPTDataLoaderResolverAddressTest.m */,
+				055AEE551A162C5E00A490BF /* SPTDataLoaderResolverTest.m */,
+				059940A81A150C90006D6BE9 /* SPTDataLoaderResponseTest.m */,
+				F7346A6D1CC2DEAA00B8AB41 /* SPTDataLoaderServerTrustPolicyTest.m */,
+				056A04BD1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m */,
+				0599409E1A14F60F006D6BE9 /* SPTDataLoaderTest.m */,
+				430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */,
 				059940951A14E7DA006D6BE9 /* Mocks */,
+				050E069A1A10C62100A10A0E /* Supporting Files */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -326,6 +341,8 @@
 				05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */,
 				2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */,
 				2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */,
+				430D3C85249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.h */,
+				430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -471,6 +488,7 @@
 				F7794B011CB5904E0092AEC6 /* SPTDataLoaderServerTrustPolicy.m in Sources */,
 				050E06AC1A10CC1300A10A0E /* SPTDataLoaderRequest.m in Sources */,
 				050E06901A10C62100A10A0E /* SPTDataLoader.m in Sources */,
+				430D3C82249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */,
 				052FB1681A127BF900AFE80E /* SPTDataLoaderResolverAddress.m in Sources */,
 				052FB1651A12793F00AFE80E /* SPTDataLoaderResolver.m in Sources */,
 				050E06BC1A10CFD700A10A0E /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
@@ -487,6 +505,7 @@
 				0599409F1A14F60F006D6BE9 /* SPTDataLoaderTest.m in Sources */,
 				05356F151A44B588003A7351 /* NSDictionaryHeaderSizeTest.m in Sources */,
 				0568B18E1A14A5FE00FEEBF8 /* SPTDataLoaderAuthoriserMock.m in Sources */,
+				430D3C87249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m in Sources */,
 				05357B401C57D35D003A8AD0 /* SPTDataLoaderExponentialTimerTest.m in Sources */,
 				2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */,
 				487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */,
@@ -506,6 +525,7 @@
 				0599409D1A14F32A006D6BE9 /* SPTDataLoaderRequestResponseHandlerDelegateMock.m in Sources */,
 				055AEE521A16117E00A490BF /* NSURLSessionTaskMock.m in Sources */,
 				055AEE561A162C5E00A490BF /* SPTDataLoaderResolverTest.m in Sources */,
+				430D3C89249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m in Sources */,
 				05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */,
 				059940971A14E7F1006D6BE9 /* SPTDataLoaderFactoryTest.m in Sources */,
 				055AEE581A162F0200A490BF /* SPTDataLoaderResolverAddressTest.m in Sources */,

--- a/SPTDataLoaderFramework.xcodeproj/project.pbxproj
+++ b/SPTDataLoaderFramework.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		2DE3DAC12344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DAC22344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DAC32344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		430D3C8C249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
+		430D3C8D249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
+		430D3C8E249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
+		430D3C8F249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
 		6992FD211F71DBD4003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6992FD221F71DC07003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6992FD231F71DC14003E1E4F /* SPTDataLoaderImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6992FD201F71DBA8003E1E4F /* SPTDataLoaderImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -175,6 +179,8 @@
 		2DE3DAB92344E0F70022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
 		2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
 		2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
+		430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementation.m; sourceTree = "<group>"; };
+		430D3C90249D19AB00791FD3 /* SPTDataLoaderTimeProviderImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderImplementation.h; sourceTree = "<group>"; };
 		6992FD1A1F71DB8B003E1E4F /* SPTDataLoaderServerTrustPolicy+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderServerTrustPolicy+Private.h"; sourceTree = "<group>"; };
 		6992FD1B1F71DB8C003E1E4F /* SPTDataLoaderImplementation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderImplementation+Private.h"; sourceTree = "<group>"; };
 		6992FD1C1F71DB8C003E1E4F /* SPTDataLoaderCancellationTokenFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCancellationTokenFactory.h; sourceTree = "<group>"; };
@@ -282,6 +288,8 @@
 				2DE3DAB92344E0F70022642E /* SPTDataLoaderService+Private.h */,
 				2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */,
 				2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */,
+				430D3C90249D19AB00791FD3 /* SPTDataLoaderTimeProviderImplementation.h */,
+				430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -594,6 +602,7 @@
 				F7346A381CC2CF8200B8AB41 /* SPTDataLoaderServerTrustPolicy.m in Sources */,
 				05A638441C46B82700061E37 /* SPTDataLoaderResolver.m in Sources */,
 				05A638451C46B82700061E37 /* SPTDataLoaderResolverAddress.m in Sources */,
+				430D3C8C249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */,
 				05A638461C46B82700061E37 /* SPTDataLoaderResponse.m in Sources */,
 				05A638471C46B82700061E37 /* SPTDataLoaderService.m in Sources */,
 				05A638481C46B82700061E37 /* SPTDataLoaderExponentialTimer.m in Sources */,
@@ -616,6 +625,7 @@
 				F7346A391CC2CF8200B8AB41 /* SPTDataLoaderServerTrustPolicy.m in Sources */,
 				05A638511C46B84B00061E37 /* SPTDataLoaderResolver.m in Sources */,
 				05A638521C46B84B00061E37 /* SPTDataLoaderResolverAddress.m in Sources */,
+				430D3C8D249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */,
 				05A638531C46B84B00061E37 /* SPTDataLoaderResponse.m in Sources */,
 				05A638541C46B84B00061E37 /* SPTDataLoaderService.m in Sources */,
 				05A638551C46B84B00061E37 /* SPTDataLoaderExponentialTimer.m in Sources */,
@@ -638,6 +648,7 @@
 				F7346A3A1CC2CF8200B8AB41 /* SPTDataLoaderServerTrustPolicy.m in Sources */,
 				05A6386B1C46B87100061E37 /* SPTDataLoaderResolver.m in Sources */,
 				05A6386C1C46B87100061E37 /* SPTDataLoaderResolverAddress.m in Sources */,
+				430D3C8E249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */,
 				05A6386D1C46B87100061E37 /* SPTDataLoaderResponse.m in Sources */,
 				05A6386E1C46B87100061E37 /* SPTDataLoaderService.m in Sources */,
 				05A6386F1C46B87100061E37 /* SPTDataLoaderExponentialTimer.m in Sources */,
@@ -660,6 +671,7 @@
 				F7346A3B1CC2CF8200B8AB41 /* SPTDataLoaderServerTrustPolicy.m in Sources */,
 				05A638351C46B7F800061E37 /* SPTDataLoaderResolver.m in Sources */,
 				05A638371C46B7F800061E37 /* SPTDataLoaderResolverAddress.m in Sources */,
+				430D3C8F249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */,
 				05A638381C46B7F800061E37 /* SPTDataLoaderResponse.m in Sources */,
 				05A6383A1C46B7F800061E37 /* SPTDataLoaderService.m in Sources */,
 				05A6383B1C46B7F800061E37 /* SPTDataLoaderExponentialTimer.m in Sources */,

--- a/Sources/SPTDataLoaderRateLimiter+Private.h
+++ b/Sources/SPTDataLoaderRateLimiter+Private.h
@@ -1,0 +1,37 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import <SPTDataLoader/SPTDataLoaderRateLimiter.h>
+
+@protocol SPTDataLoaderTimeProvider;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderRateLimiter (Private)
+
+- (instancetype)initWithDefaultRequestsPerSecond:(double)requestsPerSecond
+                                    timeProvider:(id<SPTDataLoaderTimeProvider>)timeProvider;
+
+@property (nonatomic, strong, readonly) id<SPTDataLoaderTimeProvider> timeProvider;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Sources/SPTDataLoaderTimeProvider.h
+++ b/Sources/SPTDataLoaderTimeProvider.h
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SPTDataLoaderTimeProvider <NSObject>
+
+@property (nonatomic, readonly) CFAbsoluteTime currentTime;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderTimeProvider.h
+++ b/Sources/SPTDataLoaderTimeProvider.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/Sources/SPTDataLoaderTimeProviderImplementation.h
+++ b/Sources/SPTDataLoaderTimeProviderImplementation.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderTimeProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderTimeProviderImplementation: NSObject <SPTDataLoaderTimeProvider>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderTimeProviderImplementation.h
+++ b/Sources/SPTDataLoaderTimeProviderImplementation.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/Sources/SPTDataLoaderTimeProviderImplementation.m
+++ b/Sources/SPTDataLoaderTimeProviderImplementation.m
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderTimeProviderImplementation.h"
+
+@implementation SPTDataLoaderTimeProviderImplementation
+
+- (CFAbsoluteTime)currentTime
+{
+    return CFAbsoluteTimeGetCurrent();
+}
+
+@end

--- a/Sources/SPTDataLoaderTimeProviderImplementation.m
+++ b/Sources/SPTDataLoaderTimeProviderImplementation.m
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/Tests/SPTDataLoaderRateLimiterTest.m
+++ b/Tests/SPTDataLoaderRateLimiterTest.m
@@ -20,12 +20,15 @@
  */
 #import <XCTest/XCTest.h>
 
-#import <SPTDataLoader/SPTDataLoaderRateLimiter.h>
+#import "SPTDataLoaderRateLimiter+Private.h"
+#import "SPTDataLoaderTimeProviderImplementation.h"
+#import "SPTDataLoaderTimeProviderMock.h"
 
 #import <SPTDataLoader/SPTDataLoaderRequest.h>
 
 @interface SPTDataLoaderRateLimiterTest : XCTestCase
 
+@property (nonatomic, strong) SPTDataLoaderTimeProviderMock *timeProvider;
 @property (nonatomic, strong) SPTDataLoaderRateLimiter *rateLimiter;
 @property (nonatomic, assign) double requestsPerSecond;
 
@@ -39,7 +42,9 @@
 {
     [super setUp];
     self.requestsPerSecond = 10.0;
-    self.rateLimiter = [SPTDataLoaderRateLimiter rateLimiterWithDefaultRequestsPerSecond:self.requestsPerSecond];
+    self.timeProvider = [SPTDataLoaderTimeProviderMock new];
+    self.rateLimiter = [[SPTDataLoaderRateLimiter alloc] initWithDefaultRequestsPerSecond:self.requestsPerSecond
+                                                                             timeProvider:self.timeProvider];
 }
 
 #pragma mark SPTDataLoaderRateLimiterTest
@@ -49,22 +54,96 @@
     XCTAssertNotNil(self.rateLimiter, @"The rate limiter should not be nil after construction");
 }
 
+- (void)testRateLimiterWithDefaultRequestsPerSecondUseExpectedTimeLimiter
+{
+    // Given
+    Class expectedTimeProviderClass = [SPTDataLoaderTimeProviderImplementation class];
+    
+    // When
+    SPTDataLoaderRateLimiter *const rateLimiter = [SPTDataLoaderRateLimiter rateLimiterWithDefaultRequestsPerSecond:self.requestsPerSecond];
+    
+    // Then
+    XCTAssert([rateLimiter.timeProvider isKindOfClass:expectedTimeProviderClass], @"The default timeProvider used by the class method should be a SPTDataLoaderTimeProviderImplementation");
+}
+
 - (void)testEarliestTimeUntilRequestCanBeRealisedWithRetryAfter
 {
+    // Given
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
     NSTimeInterval seconds = 60.0;
-    CFAbsoluteTime retryAfter = CFAbsoluteTimeGetCurrent() + seconds;
+    CFAbsoluteTime retryAfter = self.timeProvider.currentTime + seconds;
+    
+    // When
     [self.rateLimiter setRetryAfter:retryAfter forURL:URL];
+    
+    // Then
     NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
     XCTAssertEqualWithAccuracy(earliestTime, seconds, 1.0, @"The retry-after limitation was not respected by the rate limiter");
 }
 
-- (void)testEarliestTimeUntilRequestCanBeRealised
+- (void)testEarliestTimeWithCurrentTimeMovingBackwards
 {
+    // Given
+    self.timeProvider.currentTime = 100;
+    const double timeDelta = -100;
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
     [self.rateLimiter executedRequest:request];
+    
+    // When
+    self.timeProvider.currentTime += timeDelta;
+    
+    // Then
+    NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
+    XCTAssertEqualWithAccuracy(earliestTime, 0, 0.000000001, @"The earliestTime is not 0 although the currentTime is less than the time of the last request executed");
+}
+
+- (void)testEarliestTimeWithCurrentTimeMovingForwardLessThanCutoffTime
+{
+    // Given
+    self.timeProvider.currentTime = 100;
+    const CFAbsoluteTime cutoffTime = 0.1; // as we set 10 requests per second
+    const CFAbsoluteTime timeDelta = 0.02;
+    NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
+    [self.rateLimiter executedRequest:request];
+    
+    // When
+    self.timeProvider.currentTime += timeDelta;
+    
+    // Then
+    NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
+    XCTAssertEqualWithAccuracy(earliestTime, cutoffTime - timeDelta, 0.000000001, @"The earliestTime is not equal to the remaining part of the curoffTime");
+}
+
+- (void)testEarliestTimeWithCurrentTimeMovingForwardMoreThanCutoffTime
+{
+    // Given
+    self.timeProvider.currentTime = 100;
+    const CFAbsoluteTime timeDelta = 100;
+    NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
+    [self.rateLimiter executedRequest:request];
+    
+    // When
+    self.timeProvider.currentTime -= timeDelta;
+    
+    // Then
+    NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
+    XCTAssertEqualWithAccuracy(earliestTime, 0, 0.000000001, @"The earliestTime is not 0 although longer than the cutoff time has passed");
+}
+
+- (void)testEarliestTimeUntilRequestCanBeRealised
+{
+    // Given
+    NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
+    
+    // When
+    [self.rateLimiter executedRequest:request];
+    
+    // Then
     NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
     NSString *earliestTimeWithDecimalPrecision = [NSString stringWithFormat:@"%0.1f", earliestTime];
     XCTAssertEqualObjects(earliestTimeWithDecimalPrecision, @"0.1", @"The requests per second limitation was not respected by the rate limiter");
@@ -81,16 +160,26 @@
 
 - (void)testRequestsPerSecondDefault
 {
+    // Given
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
+    
+    // When
     double requestsPerSecond = [self.rateLimiter requestsPerSecondForURL:URL];
+    
+    // Then
     XCTAssertEqualWithAccuracy(requestsPerSecond, self.requestsPerSecond, 1.0, @"The requests per second for a URL is not falling back to the default specified in the class constructor");
 }
 
 - (void)testRequestsPerSecondCustom
 {
+    // Given
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
     double requestsPerSecond = 20.0;
+    
+    // When
     [self.rateLimiter setRequestsPerSecond:requestsPerSecond forURL:URL];
+    
+    // Then
     double reportedRequestsPerSecond = [self.rateLimiter requestsPerSecondForURL:URL];
     XCTAssertEqualWithAccuracy(requestsPerSecond, reportedRequestsPerSecond, 1.0, @"The requests per second for this URL was not what was explicitly set");
 }
@@ -106,12 +195,17 @@
 
 - (void)testResetRetryAfterAfterSuccessfulExecution
 {
+    // Given
     NSURL *URL = [NSURL URLWithString:@"https://spclient.wg.spotify.com/thingy"];
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:nil];
     NSTimeInterval seconds = 60.0;
-    CFAbsoluteTime retryAfter = CFAbsoluteTimeGetCurrent() + seconds;
+    CFAbsoluteTime retryAfter = self.timeProvider.currentTime + seconds;
+    
+    // When
     [self.rateLimiter setRetryAfter:retryAfter forURL:URL];
     [self.rateLimiter executedRequest:request];
+    
+    // Then
     NSTimeInterval earliestTime = [self.rateLimiter earliestTimeUntilRequestCanBeExecuted:request];
     XCTAssertEqualWithAccuracy(earliestTime, 0.0, 1.0, @"The earliest time until request can be executed was not reset despite an overwrite of the retry-after rule");
 }

--- a/Tests/SPTDataLoaderTimeProviderImplementationTest.m
+++ b/Tests/SPTDataLoaderTimeProviderImplementationTest.m
@@ -21,7 +21,7 @@
 #import <XCTest/XCTest.h>
 #import "SPTDataLoaderTimeProviderImplementation.h"
 
-@interface SPTDataLoaderTimeProviderImplementationTest : XCTestCase
+@interface SPTDataLoaderTimeProviderImplementationTest: XCTestCase
 
 @end
 

--- a/Tests/SPTDataLoaderTimeProviderImplementationTest.m
+++ b/Tests/SPTDataLoaderTimeProviderImplementationTest.m
@@ -1,0 +1,43 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import <XCTest/XCTest.h>
+#import "SPTDataLoaderTimeProviderImplementation.h"
+
+@interface SPTDataLoaderTimeProviderImplementationTest : XCTestCase
+
+@end
+
+@implementation SPTDataLoaderTimeProviderImplementationTest
+
+- (void)testCurrentTimeIsEqualToCFAbsoluteTimeGetCurrent
+{
+    // Given
+    const CFAbsoluteTime expectedTime = CFAbsoluteTimeGetCurrent();
+    SPTDataLoaderTimeProviderImplementation *timeProvider = [SPTDataLoaderTimeProviderImplementation new];
+    
+    // When
+    const CFAbsoluteTime actualTime = timeProvider.currentTime;
+    
+    // Time
+    XCTAssertEqualWithAccuracy(expectedTime, actualTime, 0.1, @"The currentTime is not equal to the system time given by CFAbsoluteTimeGetCurrent()");
+}
+
+@end

--- a/Tests/SPTDataLoaderTimeProviderImplementationTest.m
+++ b/Tests/SPTDataLoaderTimeProviderImplementationTest.m
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/Tests/SPTDataLoaderTimeProviderMock.h
+++ b/Tests/SPTDataLoaderTimeProviderMock.h
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderTimeProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderTimeProviderMock: NSObject <SPTDataLoaderTimeProvider>
+
+@property (nonatomic, readwrite) CFAbsoluteTime currentTime;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoaderTimeProviderMock.h
+++ b/Tests/SPTDataLoaderTimeProviderMock.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/Tests/SPTDataLoaderTimeProviderMock.m
+++ b/Tests/SPTDataLoaderTimeProviderMock.m
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderTimeProviderMock.h"
+
+@implementation SPTDataLoaderTimeProviderMock
+
+@synthesize currentTime;
+
+@end

--- a/Tests/SPTDataLoaderTimeProviderMock.m
+++ b/Tests/SPTDataLoaderTimeProviderMock.m
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-2020 Spotify AB.
- 
+
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -8,9 +8,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
**Context**
The `SPTDataLoaderRateLimiter` has a method to compute when is earliest time a new request can be executed: `earliestTimeUntilRequestCanBeExecuted`. This includes a throttle to avoid that too many requests are sent in a very short period of time. The object is initialised with a `requestsPerSecond` parameter which then determines the minimum waiting time between two requests: `1 / requestsPerSecond`.

The lines that apply this logic as follows:
```
CFAbsoluteTime deltaTime = currentTime - lastExecution;
CFAbsoluteTime cutoffTime = 1.0 / requestsPerSecond;
CFAbsoluteTime timeInterval = cutoffTime - deltaTime;
if (timeInterval < 0.0) {
  timeInterval = 0.0;
}
return timeInterval;
```

**Problem**
In normal conditions `currentTime` is always going to be larger than `lastExecution`. However there is an edge-case: if the user changes the system time (e.g. move clock backwards in iOS settings) then `currentTime` would become less than `lastExecution` and the above `deltaTime` would be unexpectedly negative. With the current logic this would affect the computation of `timeInterval` which would become ~ as large as - `deltaTime`. In other words if the user moves the clock 24h backwards we would not allow any requests for ~24h.

**Suggested Solution**
Ideally we should use a Monotonic clock (e.g. `mach_absolute_time()`) but this would require some careful consideration and major refactoring as `CFAbsoluteTimeGetCurrent()` is the reference time almost everywhere in the framework.

As I don't see any other reasons for `currentTime` being less than `lastExecution` other than the scenario described above, I think we should simply add the following check and allow requests immediately if that happens:
```
if (deltaTime < 0) {
  // If currentTime < lastExecution the system clock must have been moved backwards
  // We should execute the request immediately to allow the RateLimiter to resume working as expected
  return 0;
}
```