### PR TITLE
SPTDataLoaderAuthorizer requestFailedAuthorisation accept response now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file. SPTDataLoad
 
 --
 
+## [2.0.0](https://github.com/spotify/SPTDataLoader/releases/tag/2.0.0)
+_Released on 2020-07-23._
+
+### Changed
+* SPTDataLoaderAuthorizer: requestFailedAuthorisation also accepts SPTDataLoaderResponse (breaking change)
+* Fixed multiple issues
+
 ## [1.1.1](https://github.com/spotify/SPTDataLoader/releases/tag/1.1.1)
 _Released on 2016-02-20._
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ The SPTDataLoader architecture is designed to centralise authentication around t
     [self.delegate dataLoaderAuthoriser:self authorisedRequest:request];
 }
 
-- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request
+- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request response:(SPTDataLoaderResponse *)response
 {
     // This tells us that the server returned a 400 error code indicating that the authorisation did not work
     // Commonly this means you should attempt to get another authorisation token
+    // Or the response object should be inspected for additional information from the backend
 }
 
 - (void)refresh

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = "SPTDataLoader"
-    s.version      = "1.1.1"
+    s.version      = "2.0.0"
     s.summary      = "SPTDataLoader is Spotify’s HTTP library for Objective-C"
 
     s.description  = <<-DESC

--- a/Sources/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoaderFactory.m
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (response.error.code == SPTDataLoaderResponseHTTPStatusCodeUnauthorised && !response.request.retriedAuthorisation) {
         for (id<SPTDataLoaderAuthoriser> authoriser in self.authorisers) {
             if ([authoriser requestRequiresAuthorisation:response.request]) {
-                [authoriser requestFailedAuthorisation:response.request];
+                [authoriser requestFailedAuthorisation:response.request response:response];
             }
         }
         response.request.retriedAuthorisation = YES;

--- a/Tests/SPTDataLoaderAuthoriserMock.m
+++ b/Tests/SPTDataLoaderAuthoriserMock.m
@@ -51,7 +51,7 @@
     [self.delegate dataLoaderAuthoriser:self authorisedRequest:request];
 }
 
-- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request
+- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request response:(SPTDataLoaderResponse *)response
 {
 }
 

--- a/demo/SPTDataLoaderAuthoriserOAuth.m
+++ b/demo/SPTDataLoaderAuthoriserOAuth.m
@@ -115,7 +115,7 @@ static NSString *SPTDataLoaderAuthoriserHeader = @"Authorization";
     }
 }
 
-- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request
+- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request response:(nonnull SPTDataLoaderResponse *)response
 {
     self.accessToken = nil;
     self.expiresIn = 0.0;

--- a/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
+++ b/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
@@ -21,6 +21,7 @@
 #import <Foundation/Foundation.h>
 
 @class SPTDataLoaderRequest;
+@class SPTDataLoaderResponse;
 
 @protocol SPTDataLoaderAuthoriser;
 
@@ -77,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  Mark that a request failed authorisation
  @param request The request to authorise
  */
-- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request;
+- (void)requestFailedAuthorisation:(SPTDataLoaderRequest *)request response:(SPTDataLoaderResponse *) response;
 /**
  Refreshes any kind authorisation
  @discussion This is never called by the factory, it is expected that the authoriser will be able to handle refreshes


### PR DESCRIPTION
Sometimes authorizers need to make decisions based on the response they are getting.
This pr changes the public interface of the authorizer to receive `SPTDataLoaderResponse` in addition to `SPTDataLoaderRequest`.

this is a breaking change