### PR TITLE
Data loader: add a thin wrapper with a simple block API

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
 		3426C1ED24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */; };
+		3426C1F424CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1F324CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m */; };
 		430D3C82249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
 		430D3C87249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */; };
 		430D3C89249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */; };
@@ -156,6 +157,7 @@
 		2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelectorMock.m; sourceTree = "<group>"; };
 		3426C1EB24CB1C5D00B919B4 /* SPTDataLoaderBlockWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderBlockWrapper.h; sourceTree = "<group>"; };
 		3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderBlockWrapper.m; sourceTree = "<group>"; };
+		3426C1F324CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderBlockWrapperTest.m; sourceTree = "<group>"; };
 		430D3C80249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderImplementation.h; sourceTree = "<group>"; };
 		430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementation.m; sourceTree = "<group>"; };
 		430D3C83249CD7C300791FD3 /* SPTDataLoaderTimeProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProvider.h; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				056A04BD1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m */,
 				0599409E1A14F60F006D6BE9 /* SPTDataLoaderTest.m */,
 				430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */,
+				3426C1F324CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m */,
 				059940951A14E7DA006D6BE9 /* Mocks */,
 				050E069A1A10C62100A10A0E /* Supporting Files */,
 			);
@@ -519,6 +522,7 @@
 				F7346A301CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.m in Sources */,
 				055AEE541A16262A00A490BF /* SPTDataLoaderRateLimiterTest.m in Sources */,
 				050F53871A2756570094F2BB /* SPTDataLoaderConsumptionObserverMock.m in Sources */,
+				3426C1F424CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m in Sources */,
 				059940A51A14FA65006D6BE9 /* SPTDataLoaderCancellationTokenDelegateMock.m in Sources */,
 				059940A21A14F7E1006D6BE9 /* SPTDataLoaderDelegateMock.m in Sources */,
 				0504CB8F1A151B6D00AD54EF /* SPTDataLoaderCancellationTokenImplementationTest.m in Sources */,

--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
 		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
+		3426C1ED24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */; };
 		430D3C82249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
 		430D3C87249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */; };
 		430D3C89249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */; };
@@ -153,6 +154,8 @@
 		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
 		2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelectorMock.h; sourceTree = "<group>"; };
 		2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelectorMock.m; sourceTree = "<group>"; };
+		3426C1EB24CB1C5D00B919B4 /* SPTDataLoaderBlockWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderBlockWrapper.h; sourceTree = "<group>"; };
+		3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderBlockWrapper.m; sourceTree = "<group>"; };
 		430D3C80249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderImplementation.h; sourceTree = "<group>"; };
 		430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementation.m; sourceTree = "<group>"; };
 		430D3C83249CD7C300791FD3 /* SPTDataLoaderTimeProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProvider.h; sourceTree = "<group>"; };
@@ -256,6 +259,7 @@
 				430D3C83249CD7C300791FD3 /* SPTDataLoaderTimeProvider.h */,
 				430D3C80249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.h */,
 				430D3C81249CD77500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */,
+				3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -365,6 +369,7 @@
 				056A04B71A13D10900FA72AD /* SPTDataLoaderResponse.h */,
 				F7794AFF1CB590430092AEC6 /* SPTDataLoaderServerTrustPolicy.h */,
 				056A04B81A13D10900FA72AD /* SPTDataLoaderService.h */,
+				3426C1EB24CB1C5D00B919B4 /* SPTDataLoaderBlockWrapper.h */,
 			);
 			name = "Public API";
 			path = include/SPTDataLoader;
@@ -481,6 +486,7 @@
 				05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */,
 				2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05356F131A447295003A7351 /* NSDictionary+HeaderSize.m in Sources */,
+				3426C1ED24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */,
 				050E06AF1A10CC6B00A10A0E /* SPTDataLoaderResponse.m in Sources */,
 				050E06A61A10C68100A10A0E /* SPTDataLoaderService.m in Sources */,
 				050E06A91A10C7BE00A10A0E /* SPTDataLoaderFactory.m in Sources */,

--- a/SPTDataLoaderFramework.xcodeproj/project.pbxproj
+++ b/SPTDataLoaderFramework.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		2DE3DAC12344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DAC22344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DAC32344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */; };
+		3426C1EF24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */; };
+		3426C1F024CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */; };
+		3426C1F124CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */; };
+		3426C1F224CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */; };
 		430D3C8C249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
 		430D3C8D249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
 		430D3C8E249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */; };
@@ -179,6 +183,7 @@
 		2DE3DAB92344E0F70022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
 		2DE3DABA2344E1780022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
 		2DE3DABB2344E1780022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
+		3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderBlockWrapper.m; sourceTree = "<group>"; };
 		430D3C8B249D196500791FD3 /* SPTDataLoaderTimeProviderImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderTimeProviderImplementation.m; sourceTree = "<group>"; };
 		430D3C90249D19AB00791FD3 /* SPTDataLoaderTimeProviderImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderTimeProviderImplementation.h; sourceTree = "<group>"; };
 		6992FD1A1F71DB8B003E1E4F /* SPTDataLoaderServerTrustPolicy+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderServerTrustPolicy+Private.h"; sourceTree = "<group>"; };
@@ -268,6 +273,7 @@
 				058CCFFA1C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.h */,
 				058CCFFB1C62F90B00FF96D6 /* SPTDataLoaderCancellationTokenImplementation.m */,
 				056E523E1A113A2B00E8716C /* SPTDataLoaderExponentialTimer.m */,
+				3426C1EE24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m */,
 				050E06A81A10C7BE00A10A0E /* SPTDataLoaderFactory.m */,
 				050E06BE1A10F26800A10A0E /* SPTDataLoaderFactory+Private.h */,
 				6992FD1B1F71DB8C003E1E4F /* SPTDataLoaderImplementation+Private.h */,
@@ -595,6 +601,7 @@
 				05A6383D1C46B82700061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
 				2DE3DAC02344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6383F1C46B82700061E37 /* SPTDataLoader.m in Sources */,
+				3426C1EF24CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */,
 				05A638401C46B82700061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A638411C46B82700061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
 				05A638421C46B82700061E37 /* SPTDataLoaderRequest.m in Sources */,
@@ -618,6 +625,7 @@
 				05A6384A1C46B84B00061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
 				2DE3DAC12344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6384C1C46B84B00061E37 /* SPTDataLoader.m in Sources */,
+				3426C1F024CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */,
 				05A6384D1C46B84B00061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A6384E1C46B84B00061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
 				05A6384F1C46B84B00061E37 /* SPTDataLoaderRequest.m in Sources */,
@@ -641,6 +649,7 @@
 				05A638641C46B87100061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
 				2DE3DAC22344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A638661C46B87100061E37 /* SPTDataLoader.m in Sources */,
+				3426C1F124CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */,
 				05A638671C46B87100061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A638681C46B87100061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
 				05A638691C46B87100061E37 /* SPTDataLoaderRequest.m in Sources */,
@@ -664,6 +673,7 @@
 				05A638281C46B7F800061E37 /* SPTDataLoaderCancellationTokenFactoryImplementation.m in Sources */,
 				2DE3DAC32344E1780022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */,
 				05A6382B1C46B7F800061E37 /* SPTDataLoader.m in Sources */,
+				3426C1F224CB2E6200B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */,
 				05A6382D1C46B7F800061E37 /* SPTDataLoaderFactory.m in Sources */,
 				05A6382F1C46B7F800061E37 /* SPTDataLoaderRateLimiter.m in Sources */,
 				05A638301C46B7F800061E37 /* SPTDataLoaderRequest.m in Sources */,

--- a/Sources/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoaderBlockWrapper.m
@@ -18,7 +18,7 @@
  specific language governing permissions and limitations
  under the License.
  */
-#import "SPTDataLoaderBlockWrapper.h"
+#import <SPTDataLoader/SPTDataLoaderBlockWrapper.h>
 #import "SPTDataLoader.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoaderBlockWrapper.m
@@ -1,0 +1,87 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import "SPTDataLoaderBlockWrapper.h"
+#import "SPTDataLoader.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderBlockWrapper () <SPTDataLoaderDelegate>
+
+@property (nonatomic, strong) SPTDataLoader *dataLoader;
+@property (nonatomic, strong) NSMapTable *completionHandlers;
+
+@end
+
+@implementation SPTDataLoaderBlockWrapper
+
+- (instancetype)initWithDataLoader:(SPTDataLoader *)dataLoader
+{
+    self = [super init];
+    if (self) {
+        _dataLoader = dataLoader;
+        dataLoader.delegate = self;
+        _completionHandlers = [NSMapTable strongToWeakObjectsMapTable];
+    }
+    return self;
+}
+
+- (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request completion:(DataLoaderBlockCompletion)completion
+{
+    NSString *sourceIdentifier = request.sourceIdentifier;
+    if (sourceIdentifier == nil) {
+        // If we don't have a source identifer, we create one to uniquely identify the observer.
+        sourceIdentifier = [[NSUUID UUID] UUIDString];
+        request.sourceIdentifier = sourceIdentifier;
+    }
+
+    [self.completionHandlers setObject:completion forKey:sourceIdentifier];
+    return [self.dataLoader performRequest:request];
+}
+
+- (void)dataLoader:(nonnull SPTDataLoader *)dataLoader didReceiveErrorResponse:(nonnull SPTDataLoaderResponse *)response
+{
+    NSString *sourceIdentifier = response.request.sourceIdentifier;
+    if (!sourceIdentifier){
+        return;
+    }
+    DataLoaderBlockCompletion completion = [self.completionHandlers objectForKey:sourceIdentifier];
+    if (completion != nil) {
+        completion(response, nil);
+        [self.completionHandlers removeObjectForKey:sourceIdentifier];
+    }
+}
+
+- (void)dataLoader:(nonnull SPTDataLoader *)dataLoader didReceiveSuccessfulResponse:(nonnull SPTDataLoaderResponse *)response
+{
+    NSString *sourceIdentifier = response.request.sourceIdentifier;
+    if (!sourceIdentifier) {
+        return;
+    }
+    DataLoaderBlockCompletion completion = [self.completionHandlers objectForKey:sourceIdentifier];
+    if (completion != nil) {
+        completion(response, response.error);
+        [self.completionHandlers removeObjectForKey:sourceIdentifier];
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoaderBlockWrapper.m
@@ -45,10 +45,7 @@ static NSString * const BlockRequestIdentifierKey = @"BlockRequestIdentifierKey"
 
 - (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request completion:(SPTDataLoaderBlockCompletion)completion
 {
-    NSMutableDictionary *mutableUserInfo = [request.userInfo mutableCopy];
-    if (mutableUserInfo == nil) {
-        mutableUserInfo = [NSMutableDictionary new];
-    }
+    NSMutableDictionary *mutableUserInfo = [request.userInfo mutableCopy] ?: [NSMutableDictionary new];
     mutableUserInfo[BlockRequestIdentifierKey] = [completion copy];
     request.userInfo = mutableUserInfo;
 

--- a/Sources/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoaderFactory.m
@@ -22,13 +22,13 @@
 
 #import <SPTDataLoader/SPTDataLoaderAuthoriser.h>
 #import <SPTDataLoader/SPTDataLoaderRequest.h>
+#import <SPTDataLoader/SPTDataLoaderBlockWrapper.h>
 #import "SPTDataLoaderCancellationTokenFactoryImplementation.h"
 
 #import "SPTDataLoaderFactory+Private.h"
 #import "SPTDataLoaderImplementation+Private.h"
 #import "SPTDataLoaderResponse+Private.h"
 #import "SPTDataLoaderRequest+Private.h"
-#import "SPTDataLoaderBlockWrapper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoaderFactory.m
@@ -28,6 +28,7 @@
 #import "SPTDataLoaderImplementation+Private.h"
 #import "SPTDataLoaderResponse+Private.h"
 #import "SPTDataLoaderRequest+Private.h"
+#import "SPTDataLoaderBlockWrapper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,6 +75,12 @@ NS_ASSUME_NONNULL_BEGIN
     id<SPTDataLoaderCancellationTokenFactory> cancellationTokenFactory = [SPTDataLoaderCancellationTokenFactoryImplementation new];
     return [SPTDataLoader dataLoaderWithRequestResponseHandlerDelegate:self
                                               cancellationTokenFactory:cancellationTokenFactory];
+}
+
+- (SPTDataLoaderBlockWrapper *)createDataLoaderBlockWrapper
+{
+    SPTDataLoader *dataLoader = [self createDataLoader];
+    return [[SPTDataLoaderBlockWrapper alloc] initWithDataLoader:dataLoader];
 }
 
 #pragma mark SPTDataLoaderRequestResponseHandler

--- a/Tests/SPTDataLoaderBlockWrapperTest.m
+++ b/Tests/SPTDataLoaderBlockWrapperTest.m
@@ -1,0 +1,99 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import <XCTest/XCTest.h>
+
+#import <SPTDataLoader/SPTDataLoaderRequest.h>
+
+#import "SPTDataLoaderImplementation+Private.h"
+#import "SPTDataLoaderRequestResponseHandlerDelegateMock.h"
+#import "SPTDataLoaderResponse+Private.h"
+#import "SPTDataLoaderCancellationTokenFactoryMock.h"
+
+@interface SPTDataLoaderBlockWrapperTest : XCTestCase
+
+@property (nonatomic, strong) SPTDataLoader *dataLoader;
+@property (nonatomic, strong) SPTDataLoaderBlockWrapper *dataLoaderBlockWrapper;
+
+@property (nonatomic, strong) SPTDataLoaderRequestResponseHandlerDelegateMock *requestResponseHandlerDelegate;
+
+@property (nonatomic, strong, readwrite) SPTDataLoaderCancellationTokenFactoryMock *factoryMock;
+
+@end
+
+@implementation SPTDataLoaderBlockWrapperTest
+
+#pragma mark XCTestCase
+
+- (void)setUp
+{
+    [super setUp];
+    self.requestResponseHandlerDelegate = [SPTDataLoaderRequestResponseHandlerDelegateMock new];
+    self.factoryMock = [SPTDataLoaderCancellationTokenFactoryMock new];
+    self.dataLoader = [SPTDataLoader dataLoaderWithRequestResponseHandlerDelegate:self.requestResponseHandlerDelegate
+                                                         cancellationTokenFactory:self.factoryMock];
+    self.dataLoaderBlockWrapper = [[SPTDataLoaderBlockWrapper alloc] initWithDataLoader:self.dataLoader];
+}
+
+#pragma mark SPTDataLoaderTest
+
+- (void)testNotNil
+{
+    XCTAssertNotNil(self.dataLoaderBlockWrapper, @"The data loader block wrapper should not be nil after construction");
+}
+
+- (void)testPerformRequestRelayedToRequestResponseHandlerDelegate
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    [self.dataLoaderBlockWrapper performRequest:request completion:^(SPTDataLoaderResponse * _Nonnull response, NSError * _Nullable error) {
+
+    }];
+    XCTAssertNotNil(self.requestResponseHandlerDelegate.lastRequestPerformed, @"Their should be a valid last request performed");
+}
+
+- (void)testRelaySuccessfulResponseToDelegate
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *mockResponse = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Expected response"];
+    [self.dataLoaderBlockWrapper performRequest:request completion:^(SPTDataLoaderResponse * _Nonnull response, NSError * _Nullable error) {
+        if (response == mockResponse) {
+            [expectation fulfill];
+        }
+    }];
+    [self.dataLoader successfulResponse:mockResponse];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testRelayFailureResponseToDelegate
+{
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    SPTDataLoaderResponse *mockResponse = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Expected response"];
+    [self.dataLoaderBlockWrapper performRequest:request completion:^(SPTDataLoaderResponse * _Nonnull response, NSError * _Nullable error) {
+        if (response == mockResponse) {
+            [expectation fulfill];
+        }
+    }];
+    [self.dataLoader failedResponse:mockResponse];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+@end

--- a/Tests/SPTDataLoaderFactoryTest.m
+++ b/Tests/SPTDataLoaderFactoryTest.m
@@ -70,6 +70,12 @@
     XCTAssertNotNil(dataLoader, @"The data loader created by the factory is nil");
 }
 
+- (void)testCreateDataLoaderBlockWrapper
+{
+    SPTDataLoaderBlockWrapper *dataLoaderBlockWrapper = [self.factory createDataLoaderBlockWrapper];
+    XCTAssertNotNil(dataLoaderBlockWrapper, @"The data loader created by the factory is nil");
+}
+
 - (void)testSuccessfulResponse
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandler = [SPTDataLoaderRequestResponseHandlerMock new];

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -32,3 +32,4 @@
 #import <SPTDataLoader/SPTDataLoaderResponse.h>
 #import <SPTDataLoader/SPTDataLoaderServerTrustPolicy.h>
 #import <SPTDataLoader/SPTDataLoaderService.h>
+#import <SPTDataLoader/SPTDataLoaderBlockWrapper.h>

--- a/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
+++ b/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
@@ -1,0 +1,51 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import <Foundation/Foundation.h>
+
+@class SPTDataLoader;
+@class SPTDataLoaderRequest;
+@class SPTDataLoaderResponse;
+@protocol SPTDataLoaderCancellationToken;
+
+typedef void (^DataLoaderBlockCompletion)(SPTDataLoaderResponse * _Nonnull response, NSError *_Nullable error);
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A wrapper providing a block interface for the common use case of SPTDataLoader
+ */
+@interface SPTDataLoaderBlockWrapper : NSObject
+
+/// Initialises a data loader block wrapper
+/// @param dataLoader An SPTDataLoader object
+- (instancetype)initWithDataLoader:(SPTDataLoader *)dataLoader;
+
+
+/// Performs a request and returns a cancellation token associated with it.
+/// @param request The object describing the kind of request to be performed
+/// @param completion A completion block with the response and an error object
+/// @return A cancellation token associated with the request, or `nil` if the request coulnd’t be performed.
+- (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request
+                                                   completion:(DataLoaderBlockCompletion)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
+++ b/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
@@ -25,7 +25,7 @@
 @class SPTDataLoaderResponse;
 @protocol SPTDataLoaderCancellationToken;
 
-typedef void (^DataLoaderBlockCompletion)(SPTDataLoaderResponse * _Nonnull response, NSError *_Nullable error);
+typedef void (^SPTDataLoaderBlockCompletion)(SPTDataLoaderResponse * _Nonnull response, NSError *_Nullable error);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param completion A completion block with the response and an error object
 /// @return A cancellation token associated with the request, or `nil` if the request coulnd’t be performed.
 - (nullable id<SPTDataLoaderCancellationToken>)performRequest:(SPTDataLoaderRequest *)request
-                                                   completion:(DataLoaderBlockCompletion)completion;
+                                                   completion:(SPTDataLoaderBlockCompletion)completion;
 
 @end
 

--- a/include/SPTDataLoader/SPTDataLoaderFactory.h
+++ b/include/SPTDataLoader/SPTDataLoaderFactory.h
@@ -21,6 +21,7 @@
 #import <Foundation/Foundation.h>
 
 @class SPTDataLoader;
+@class SPTDataLoaderBlockWrapper;
 @protocol SPTDataLoaderAuthoriser;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -45,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
  Creates a data loader
  */
 - (SPTDataLoader *)createDataLoader;
+
+/**
+ Creates a data loader with a block API
+ */
+- (SPTDataLoaderBlockWrapper *)createDataLoaderBlockWrapper;
 
 @end
 


### PR DESCRIPTION
Looking at usages of Data Loader within Spotify and specifically in Swift features, many engineers are looking for a block based API to handle the common cases of data loading. 

This idea was already explored in https://github.com/spotify/SPTDataLoader/pull/186 but seemed to have been abandoned. 

This PR builds on top of the previous discussion and creates a thin wrapper that provides a block based API. The API design should also nudge users to handle the error case.

@dflems @erikprice @themackworth @JensAyton @rastersize 