### PR TITLE
STPDataLoaderBlockWrapper: Fix callbacks

### DIFF
--- a/Sources/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoaderBlockWrapper.m
@@ -55,7 +55,7 @@ static NSString * const BlockRequestIdentifierKey = @"BlockRequestIdentifierKey"
 {
     SPTDataLoaderBlockCompletion completion = response.request.userInfo[BlockRequestIdentifierKey];
     if (completion != nil) {
-        completion(response, nil);
+        completion(response, response.error);
     }
 }
 
@@ -63,7 +63,7 @@ static NSString * const BlockRequestIdentifierKey = @"BlockRequestIdentifierKey"
 {
     SPTDataLoaderBlockCompletion completion = response.request.userInfo[BlockRequestIdentifierKey];
     if (completion != nil) {
-        completion(response, response.error);
+        completion(response, nil);
     }
 }
 

--- a/Tests/SPTDataLoaderBlockWrapperTest.m
+++ b/Tests/SPTDataLoaderBlockWrapperTest.m
@@ -75,9 +75,8 @@
     SPTDataLoaderResponse *mockResponse = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Expected response"];
     [self.dataLoaderBlockWrapper performRequest:request completion:^(SPTDataLoaderResponse * _Nonnull response, NSError * _Nullable error) {
-        if (response == mockResponse) {
-            [expectation fulfill];
-        }
+        XCTAssertTrue(response == mockResponse && error == nil);
+        [expectation fulfill];
     }];
     [self.dataLoader successfulResponse:mockResponse];
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
@@ -86,12 +85,13 @@
 - (void)testRelayFailureResponseToDelegate
 {
     SPTDataLoaderRequest *request = [SPTDataLoaderRequest new];
+    NSError *expectedError = [NSError errorWithDomain:@"random.domain" code:33 userInfo:nil];
     SPTDataLoaderResponse *mockResponse = [SPTDataLoaderResponse dataLoaderResponseWithRequest:request response:nil];
+    mockResponse.error = expectedError;
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Expected response"];
     [self.dataLoaderBlockWrapper performRequest:request completion:^(SPTDataLoaderResponse * _Nonnull response, NSError * _Nullable error) {
-        if (response == mockResponse) {
-            [expectation fulfill];
-        }
+        XCTAssertTrue(response == mockResponse && error == expectedError);
+        [expectation fulfill];
     }];
     [self.dataLoader failedResponse:mockResponse];
     [self waitForExpectationsWithTimeout:1.0 handler:nil];


### PR DESCRIPTION
## What changed:
- pass nil error in case of successful response and error in case of failure, update unit tests

## Why changed:
- fix block based api to pass an error back in case of failure