### PR TITLE
Accept-Language: deduplicate preferred localizations

### DIFF
--- a/Sources/SPTDataLoaderRequest.m
+++ b/Sources/SPTDataLoaderRequest.m
@@ -153,9 +153,11 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
         return [NSString stringWithFormat:SPTDataLoaderRequestLanguageFormatString, language, languageImportance];
     };
 
-    NSArray *languages = [NSBundle mainBundle].preferredLocalizations;
+    NSArray<NSString *> *localizations = [NSBundle mainBundle].preferredLocalizations;
+    NSMutableOrderedSet<NSString *> *languages = [NSMutableOrderedSet orderedSetWithArray:localizations];
     if (languages.count > SPTDataLoaderRequestMaximumLanguages) {
-        languages = [languages subarrayWithRange:NSMakeRange(0, SPTDataLoaderRequestMaximumLanguages)];
+        const NSUInteger excess = languages.count - SPTDataLoaderRequestMaximumLanguages;
+        [languages removeObjectsInRange:NSMakeRange(SPTDataLoaderRequestMaximumLanguages, excess)];
     }
     double languageImportanceCounter = 1.0;
     NSMutableArray *languageHeaderValues = [NSMutableArray arrayWithCapacity:languages.count];

--- a/Tests/SPTDataLoaderRequestTest.m
+++ b/Tests/SPTDataLoaderRequestTest.m
@@ -198,6 +198,26 @@
     XCTAssertEqualObjects(@"fr-CA, en;q=0.50", languageValues);
 }
 
+- (void)testAcceptLanguageRemovesDuplicateLocalizations
+{
+    NSBundleMock *bundleMock = [NSBundleMock new];
+    bundleMock.mockPreferredLocalizations = @[ @"es-419", @"es-419", @"pt-PT" ];
+
+    Method originalMethod = class_getClassMethod(NSBundle.class, @selector(mainBundle));
+    IMP originalMethodImplementation = method_getImplementation(originalMethod);
+
+    IMP fakeMethodImplementation = imp_implementationWithBlock(^ {
+        return bundleMock;
+    });
+    method_setImplementation(originalMethod, fakeMethodImplementation);
+
+    NSString *languageValues = [SPTDataLoaderRequest generateLanguageHeaderValue];
+
+    method_setImplementation(originalMethod, originalMethodImplementation);
+
+    XCTAssertEqualObjects(@"es-419, pt-PT;q=0.50, en;q=0.01", languageValues);
+}
+
 - (void)testDeleteMethod
 {
     self.request.method = SPTDataLoaderRequestMethodDelete;


### PR DESCRIPTION
Anecdotally, it seems that NSBundle.preferredLocalizations can return
a list containing duplicate values.