### PR TITLE
Add an option to use background session.

### DIFF
--- a/Sources/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoaderService.m
@@ -36,6 +36,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static NSString *const SPTDataLoaderBackgroundSessionConfigurationIdentifier = @"SPTDataLoaderBackgroundSessionConfigurationIdentifier";
+
 @interface SPTDataLoaderService () <SPTDataLoaderRequestResponseHandlerDelegate, NSURLSessionDataDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate>
 
 
@@ -70,11 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithConfiguration:configuration rateLimiter:rateLimiter resolver:resolver];
 }
 
-+ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
-                           backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration
++ (instancetype)backgroundCapableDataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
 {
-    return [[self alloc] initWithConfiguration:configuration
-                       backgroundConfiguration:backgroundConfiguration];
+    return [[self alloc] initForBackgroundWithConfiguration:configuration];
 }
 
 + (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
@@ -149,14 +149,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
-              backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration
+- (instancetype)initForBackgroundWithConfiguration:(NSURLSessionConfiguration *)configuration
 {
     self = [self initWithConfiguration:configuration rateLimiter:nil resolver:nil];
 
     if (self) {
+        NSURLSessionConfiguration *backgroundSessionConfiguration =
+            [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:SPTDataLoaderBackgroundSessionConfigurationIdentifier];
         _sessionSelector = [[SPTDataLoaderServiceDefaultSessionSelector alloc] initWithConfiguration:configuration
-                                                                             backgroundConfiguration:backgroundConfiguration
+                                                                             backgroundConfiguration:backgroundSessionConfiguration
                                                                                             delegate:self
                                                                                        delegateQueue:_sessionQueue];
     }

--- a/Sources/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoaderService.m
@@ -70,6 +70,13 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithConfiguration:configuration rateLimiter:rateLimiter resolver:resolver];
 }
 
++ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
+                           backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration
+{
+    return [[self alloc] initWithConfiguration:configuration
+                       backgroundConfiguration:backgroundConfiguration];
+}
+
 + (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
                                    rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
                                       resolver:(nullable SPTDataLoaderResolver *)resolver
@@ -137,6 +144,21 @@ NS_ASSUME_NONNULL_BEGIN
 
         _fileManager = [NSFileManager defaultManager];
         _dataClass = [NSData class];
+    }
+
+    return self;
+}
+
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+              backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration
+{
+    self = [self initWithConfiguration:configuration rateLimiter:nil resolver:nil];
+
+    if (self) {
+        _sessionSelector = [[SPTDataLoaderServiceDefaultSessionSelector alloc] initWithConfiguration:configuration
+                                                                             backgroundConfiguration:backgroundConfiguration
+                                                                                            delegate:self
+                                                                                       delegateQueue:_sessionQueue];
     }
 
     return self;

--- a/Sources/SPTDataLoaderServiceSessionSelector.h
+++ b/Sources/SPTDataLoaderServiceSessionSelector.h
@@ -45,6 +45,22 @@ NS_ASSUME_NONNULL_BEGIN
                              delegate:(id<NSURLSessionDelegate>)delegate
                         delegateQueue:(NSOperationQueue *)delegateQueue;
 
+/**
+ Initialize a new selector object and enable background networking.
+
+ @param configuration A configuration used to create URL session for foreground work.
+ @param backgroundConfiguration A configuration for a background URL session used for background tasks.
+ @param delegate The delegate to receive URL session updates.
+ @param delegateQueue The queue to receive delegate updates in.
+
+ @discussion This method will create a background URL session which will be returned for all requests with background
+ policy value set to @c SPTDataLoaderRequestBackgroundPolicyAlways.
+ */
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+              backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration
+                             delegate:(id<NSURLSessionDelegate>)delegate
+                        delegateQueue:(NSOperationQueue *)delegateQueue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoaderServiceSessionSelector.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) NSURLSessionConfiguration *configuration;
 @property (nonatomic, strong, readonly, nullable) NSURLSessionConfiguration *backgroundConfiguration;
-@property (nonatomic, strong, readwrite, nullable) NSURLSession *backgroundSession;
+@property (nonatomic, strong, readonly, nullable) NSURLSession *backgroundSession;
 @property (nonatomic, weak, readonly) id<NSURLSessionDelegate> delegate;
 @property (nonatomic, strong, readonly) NSOperationQueue *delegateQueue;
 
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSURLSession *_nonWaitingSession;
     NSURLSession *_waitingSession;
+    NSURLSession *_backgroundSession;
 }
 
 - (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -67,6 +67,18 @@ NS_ASSUME_NONNULL_BEGIN
                                           resolver:(nullable SPTDataLoaderResolver *)resolver;
 
 /**
+ Convenience constructro with background networking settings.
+ @param configuration Custom session configuration.
+ @param backgroundConfiguration Configuration for a background session.
+
+ @discussion Use this method to create a service object which can perform network requests in background. The background
+ configuration object will be used to create a background URL session which will handle all requests with background po-
+ licy set to @c SPTDataLoaderRequestBackgroundPolicyAlways.
+ */
++ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
+                           backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration;
+
+/**
  Class constructor with QoS
  @param userAgent The user agent to report as when making HTTP requests
  @param rateLimiter The limiter for limiting requests per second on a per service basis

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -67,16 +67,15 @@ NS_ASSUME_NONNULL_BEGIN
                                           resolver:(nullable SPTDataLoaderResolver *)resolver;
 
 /**
- Convenience constructro with background networking settings.
- @param configuration Custom session configuration.
- @param backgroundConfiguration Configuration for a background session.
+ Convenience method for creating a service with background networking capabilities.
+ @param configuration A configuration object for the URL session which will handle requests in foreground.
 
- @discussion Use this method to create a service object which can perform network requests in background. The background
- configuration object will be used to create a background URL session which will handle all requests with background po-
- licy set to @c SPTDataLoaderRequestBackgroundPolicyAlways.
+ @discussion Use this method to create a service object which can perform network requests in background. A separate
+ background URL session will be created for handling all requests with background policy set to
+ @c SPTDataLoaderRequestBackgroundPolicyAlways. The rest of the requests will be performed as usual, by the session with
+ the provided configuration.
  */
-+ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
-                           backgroundConfiguration:(NSURLSessionConfiguration *)backgroundConfiguration;
++ (instancetype)backgroundCapableDataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration;
 
 /**
  Class constructor with QoS


### PR DESCRIPTION
**What has changed**
I added a new initializers to the session selector and the data loader service to enable background networking.

**Why this was changed**
Using background sessions together with download tasks is necessary for networking on watchOS. See details [here](https://developer.apple.com/documentation/watchkit/keeping_your_watchos_content_up_to_date/making_background_requests?language=objc).