### PR TITLE
Session selector: Use a background session for background requests

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */; };
 		05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */; };
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
+		2C27BAFB250A2DAF00723E20 /* SPTDataLoaderServiceDefaultSessionSelectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C27BAFA250A2DAF00723E20 /* SPTDataLoaderServiceDefaultSessionSelectorTests.m */; };
+		2C27BAFE250A4BEB00723E20 /* NSURLSessionDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C27BAFD250A4BEB00723E20 /* NSURLSessionDelegateMock.m */; };
 		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
 		3426C1ED24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */; };
@@ -150,6 +152,9 @@
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
 		05EEB73D1C5C090B00A82266 /* NSBundleMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBundleMock.h; sourceTree = "<group>"; };
 		05EEB73E1C5C090B00A82266 /* NSBundleMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBundleMock.m; sourceTree = "<group>"; };
+		2C27BAFA250A2DAF00723E20 /* SPTDataLoaderServiceDefaultSessionSelectorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceDefaultSessionSelectorTests.m; sourceTree = "<group>"; };
+		2C27BAFC250A4BEB00723E20 /* NSURLSessionDelegateMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDelegateMock.h; sourceTree = "<group>"; };
+		2C27BAFD250A4BEB00723E20 /* NSURLSessionDelegateMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDelegateMock.m; sourceTree = "<group>"; };
 		2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
 		2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
 		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
@@ -285,6 +290,7 @@
 				0599409E1A14F60F006D6BE9 /* SPTDataLoaderTest.m */,
 				430D3C88249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m */,
 				3426C1F324CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m */,
+				2C27BAFA250A2DAF00723E20 /* SPTDataLoaderServiceDefaultSessionSelectorTests.m */,
 				059940951A14E7DA006D6BE9 /* Mocks */,
 				050E069A1A10C62100A10A0E /* Supporting Files */,
 			);
@@ -350,6 +356,8 @@
 				2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */,
 				430D3C85249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.h */,
 				430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */,
+				2C27BAFC250A4BEB00723E20 /* NSURLSessionDelegateMock.h */,
+				2C27BAFD250A4BEB00723E20 /* NSURLSessionDelegateMock.m */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -520,6 +528,7 @@
 				487FE3C720588E6E007141F9 /* NSURLSessionDownloadTaskMock.m in Sources */,
 				EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */,
 				F7346A301CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.m in Sources */,
+				2C27BAFB250A2DAF00723E20 /* SPTDataLoaderServiceDefaultSessionSelectorTests.m in Sources */,
 				055AEE541A16262A00A490BF /* SPTDataLoaderRateLimiterTest.m in Sources */,
 				050F53871A2756570094F2BB /* SPTDataLoaderConsumptionObserverMock.m in Sources */,
 				3426C1F424CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m in Sources */,
@@ -529,6 +538,7 @@
 				0504CB8D1A151B0600AD54EF /* SPTDataLoaderCancellationTokenFactoryImplementationTest.m in Sources */,
 				056A04BE1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m in Sources */,
 				059940A91A150C90006D6BE9 /* SPTDataLoaderResponseTest.m in Sources */,
+				2C27BAFE250A4BEB00723E20 /* NSURLSessionDelegateMock.m in Sources */,
 				48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */,
 				F7346A6E1CC2DEAA00B8AB41 /* SPTDataLoaderServerTrustPolicyTest.m in Sources */,
 				059940A71A150275006D6BE9 /* SPTDataLoaderRequestTest.m in Sources */,

--- a/Sources/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoaderServiceSessionSelector.m
@@ -96,8 +96,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)invalidateAndCancel
 {
-    [self.waitingSession invalidateAndCancel];
-    [self.nonWaitingSession invalidateAndCancel];
+    [_waitingSession invalidateAndCancel];
+    [_nonWaitingSession invalidateAndCancel];
 }
 
 @end

--- a/Sources/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoaderServiceSessionSelector.m
@@ -30,7 +30,6 @@ static NSString *const SPTDataLoaderBackgroundSessionConfigurationIdentifier =
 @interface SPTDataLoaderServiceDefaultSessionSelector ()
 
 @property (nonatomic, strong, readonly) NSURLSessionConfiguration *configuration;
-@property (nonatomic, strong, readonly) NSURLSession *backgroundSession;
 @property (nonatomic, weak, readonly) id<NSURLSessionDelegate> delegate;
 @property (nonatomic, strong, readonly) NSOperationQueue *delegateQueue;
 

--- a/Tests/NSURLSessionDelegateMock.h
+++ b/Tests/NSURLSessionDelegateMock.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURLSessionDelegateMock : NSObject <NSURLSessionDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/NSURLSessionDelegateMock.m
+++ b/Tests/NSURLSessionDelegateMock.m
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "NSURLSessionDelegateMock.h"
+
+@implementation NSURLSessionDelegateMock
+
+@end

--- a/Tests/SPTDataLoaderServiceDefaultSessionSelectorTests.m
+++ b/Tests/SPTDataLoaderServiceDefaultSessionSelectorTests.m
@@ -1,0 +1,84 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "SPTDataLoaderServiceSessionSelector.h"
+
+#import "NSURLSessionDelegateMock.h"
+
+#import <SPTDataLoader/SPTDataLoaderRequest.h>
+#import <XCTest/XCTest.h>
+
+@interface SPTDataLoaderServiceDefaultSessionSelectorTests : XCTestCase
+
+@property (nonatomic, strong) SPTDataLoaderServiceDefaultSessionSelector *sessionSelector;
+@property (nonatomic, strong) NSOperationQueue *operationQueue;
+@property (nonatomic, strong) id<NSURLSessionDelegate> sessionDelegateMock;
+@property (nonatomic, strong) NSURL *testURL;
+@property (nonatomic, strong) SPTDataLoaderRequest *testRequest;
+
+@end
+
+@implementation SPTDataLoaderServiceDefaultSessionSelectorTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.testURL = [NSURL URLWithString:@"https://spotify.com"];
+    self.operationQueue = [NSOperationQueue mainQueue];
+    self.sessionDelegateMock = [NSURLSessionDelegateMock new];
+    self.testRequest = [SPTDataLoaderRequest requestWithURL:self.testURL sourceIdentifier:nil];
+
+    NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    self.sessionSelector =
+    [[SPTDataLoaderServiceDefaultSessionSelector alloc] initWithConfiguration:sessionConfiguration
+                                                                     delegate:self.sessionDelegateMock
+                                                                delegateQueue:self.operationQueue];
+}
+
+- (void)testNotNilSession
+{
+    NSURLSession *session = [self.sessionSelector URLSessionForRequest:self.testRequest];
+    XCTAssertNotNil(session);
+}
+
+- (void)testSessionDelegateAndQueue
+{
+    NSURLSession *session = [self.sessionSelector URLSessionForRequest:self.testRequest];
+    XCTAssertEqual(session.delegate, self.sessionDelegateMock);
+    XCTAssertEqual(session.delegateQueue, self.operationQueue);
+}
+
+- (void)testSessionForBackgroundRequest
+{
+    NSURLSession *defaultSession = [self.sessionSelector URLSessionForRequest:self.testRequest];
+
+    SPTDataLoaderRequest *backgroundRequest = [SPTDataLoaderRequest requestWithURL:self.testURL sourceIdentifier:nil];
+    backgroundRequest.backgroundPolicy = SPTDataLoaderRequestBackgroundPolicyAlways;
+    NSURLSession *backgroundSession = [self.sessionSelector URLSessionForRequest:backgroundRequest];
+
+    // Should return a different session object for a background request.
+    XCTAssertNotEqual(defaultSession, backgroundSession);
+    // A background session object should have an identifier.
+    XCTAssertNotNil(backgroundSession.configuration.identifier);
+}
+
+@end


### PR DESCRIPTION
Another take on background downloads.

This will create a background session in session selector to use for all requests with background policy set to `SPTDataLoaderRequestBackgroundPolicyAlways`.