### PR TITLE
Data loader service: Notify observers about background URL session events

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandler.m; sourceTree = "<group>"; };
 		05EEB73D1C5C090B00A82266 /* NSBundleMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBundleMock.h; sourceTree = "<group>"; };
 		05EEB73E1C5C090B00A82266 /* NSBundleMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBundleMock.m; sourceTree = "<group>"; };
+		2C9560E525091BA200EE3DBE /* SPTDataLoaderServiceEventObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceEventObserver.h; sourceTree = "<group>"; };
 		2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
 		2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
 		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
@@ -373,6 +374,7 @@
 				F7794AFF1CB590430092AEC6 /* SPTDataLoaderServerTrustPolicy.h */,
 				056A04B81A13D10900FA72AD /* SPTDataLoaderService.h */,
 				3426C1EB24CB1C5D00B919B4 /* SPTDataLoaderBlockWrapper.h */,
+				2C9560E525091BA200EE3DBE /* SPTDataLoaderServiceEventObserver.h */,
 			);
 			name = "Public API";
 			path = include/SPTDataLoader;

--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */; };
 		05CB0C451A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CB0C441A1A1E8A00CA4CEF /* SPTDataLoaderRequestTaskHandler.m */; };
 		05EEB73F1C5C090B00A82266 /* NSBundleMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EEB73E1C5C090B00A82266 /* NSBundleMock.m */; };
+		2CF13C0C250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CF13C0B250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.m */; };
 		2DE3DAC72344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */; };
 		2DE3DACA2344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */; };
 		3426C1ED24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3426C1EC24CB1C7B00B919B4 /* SPTDataLoaderBlockWrapper.m */; };
@@ -151,6 +152,8 @@
 		05EEB73D1C5C090B00A82266 /* NSBundleMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSBundleMock.h; sourceTree = "<group>"; };
 		05EEB73E1C5C090B00A82266 /* NSBundleMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSBundleMock.m; sourceTree = "<group>"; };
 		2C9560E525091BA200EE3DBE /* SPTDataLoaderServiceEventObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceEventObserver.h; sourceTree = "<group>"; };
+		2CF13C0A250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceEventObserverMock.h; sourceTree = "<group>"; };
+		2CF13C0B250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceEventObserverMock.m; sourceTree = "<group>"; };
 		2DE3DAC42344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderServiceSessionSelector.m; sourceTree = "<group>"; };
 		2DE3DAC52344E3DA0022642E /* SPTDataLoaderServiceSessionSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderServiceSessionSelector.h; sourceTree = "<group>"; };
 		2DE3DAC62344E3DA0022642E /* SPTDataLoaderService+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTDataLoaderService+Private.h"; sourceTree = "<group>"; };
@@ -347,6 +350,8 @@
 				05EEB73E1C5C090B00A82266 /* NSBundleMock.m */,
 				05A3BCB41D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.h */,
 				05A3BCB51D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m */,
+				2CF13C0A250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.h */,
+				2CF13C0B250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.m */,
 				2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */,
 				2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */,
 				430D3C85249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.h */,
@@ -538,6 +543,7 @@
 				055AEE521A16117E00A490BF /* NSURLSessionTaskMock.m in Sources */,
 				055AEE561A162C5E00A490BF /* SPTDataLoaderResolverTest.m in Sources */,
 				430D3C89249CE75100791FD3 /* SPTDataLoaderTimeProviderImplementationTest.m in Sources */,
+				2CF13C0C250AA4190021F836 /* SPTDataLoaderServiceEventObserverMock.m in Sources */,
 				05A3BCB61D649CC000735F87 /* SPTDataLoaderCancellationTokenFactoryMock.m in Sources */,
 				059940971A14E7F1006D6BE9 /* SPTDataLoaderFactoryTest.m in Sources */,
 				055AEE581A162F0200A490BF /* SPTDataLoaderResolverAddressTest.m in Sources */,

--- a/Tests/SPTDataLoaderServiceEventObserverMock.h
+++ b/Tests/SPTDataLoaderServiceEventObserverMock.h
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import <SPTDataLoader/SPTDataLoaderServiceEventObserver.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderServiceEventObserverMock : NSObject <SPTDataLoaderServiceEventObserver>
+
+@property (nonatomic, assign, readonly) NSInteger timesCalled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoaderServiceEventObserverMock.m
+++ b/Tests/SPTDataLoaderServiceEventObserverMock.m
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2015-2020 Spotify AB.
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+#import "SPTDataLoaderServiceEventObserverMock.h"
+
+@interface SPTDataLoaderServiceEventObserverMock ()
+
+@property (nonatomic, assign, readwrite) NSInteger timesCalled;
+
+@end
+
+@implementation SPTDataLoaderServiceEventObserverMock
+
+#if !TARGET_OS_OSX
+
+- (void)dataLoaderServiceDidFinishBackgroundEvents:(SPTDataLoaderService *)dataLoaderService
+{
+    self.timesCalled++;
+}
+
+#endif
+
+@end

--- a/Tests/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoaderServiceTest.m
@@ -36,6 +36,7 @@
 #import "NSURLSessionDownloadTaskMock.h"
 #import "SPTDataLoaderRequest+Private.h"
 #import "NSURLSessionTaskMock.h"
+#import "SPTDataLoaderServiceEventObserverMock.h"
 #import "SPTDataLoaderServerTrustPolicyMock.h"
 #import "NSURLAuthenticationChallengeMock.h"
 #import "SPTDataLoaderCancellationTokenDelegateMock.h"
@@ -442,6 +443,20 @@
     [self.service URLSession:self.session task:[NSURLSessionDataTaskMock new] didCompleteWithError:nil];
     XCTAssertEqual(consumptionObserver.numberOfCallsToEndedRequest, 1, @"There should be 1 call to the consumption observer when the observer has been removed");
 }
+
+#if !TARGET_OS_OSX
+
+- (void)testEventObserverCalled
+{
+    SPTDataLoaderServiceEventObserverMock *eventObserverMock = [SPTDataLoaderServiceEventObserverMock new];
+    [self.service addEventObserver:eventObserverMock on:dispatch_get_main_queue()];
+
+    [(id<NSURLSessionDelegate>)self.service URLSessionDidFinishEventsForBackgroundURLSession:self.session];
+
+    XCTAssertEqual(eventObserverMock.timesCalled, 1);
+}
+
+#endif
 
 - (void)testAllowingAllCertificates
 {

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -29,6 +29,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPTDataLoaderConsumptionObserver;
+@protocol SPTDataLoaderServiceEventObserver;
 
 /**
  The service used for creating data loader factories and providing application wide rate limiting to services
@@ -110,6 +111,22 @@ NS_ASSUME_NONNULL_BEGIN
  @param consumptionObserver The consumption observer to remove from the service
  */
 - (void)removeConsumptionObserver:(id<SPTDataLoaderConsumptionObserver>)consumptionObserver;
+
+/**
+ Adds an event observer.
+ @param eventObserver The observer to add.
+ @param queue The queue to dispatch the events to.
+
+ @note The service keeps weak references to event observer objects.
+ */
+- (void)addEventObserver:(id<SPTDataLoaderServiceEventObserver>)eventObserver on:(dispatch_queue_t)queue;
+
+/**
+ Removes an event observer.
+ @param eventObserver The observer to remove.
+ */
+- (void)removeEventObserver:(id<SPTDataLoaderServiceEventObserver>)eventObserver;
+
 /**
  Sets an server trust policy object. Used when evaluating a servers SSL certificate for the purposes of SSL pinning.
  @discussion When `allCertificatesAllowed` is true, the server trust policy will be bypassed

--- a/include/SPTDataLoader/SPTDataLoaderServiceEventObserver.h
+++ b/include/SPTDataLoader/SPTDataLoaderServiceEventObserver.h
@@ -19,18 +19,23 @@
  under the License.
  */
 
-#import <SPTDataLoader/SPTDataLoaderAuthoriser.h>
-#import <SPTDataLoader/SPTDataLoaderCancellationToken.h>
-#import <SPTDataLoader/SPTDataLoaderConsumptionObserver.h>
-#import <SPTDataLoader/SPTDataLoaderDelegate.h>
-#import <SPTDataLoader/SPTDataLoaderServiceEventObserver.h>
-#import <SPTDataLoader/SPTDataLoaderExponentialTimer.h>
-#import <SPTDataLoader/SPTDataLoaderFactory.h>
-#import <SPTDataLoader/SPTDataLoaderImplementation.h>
-#import <SPTDataLoader/SPTDataLoaderRateLimiter.h>
-#import <SPTDataLoader/SPTDataLoaderRequest.h>
-#import <SPTDataLoader/SPTDataLoaderResolver.h>
-#import <SPTDataLoader/SPTDataLoaderResponse.h>
-#import <SPTDataLoader/SPTDataLoaderServerTrustPolicy.h>
-#import <SPTDataLoader/SPTDataLoaderService.h>
-#import <SPTDataLoader/SPTDataLoaderBlockWrapper.h>
+#import <Foundation/Foundation.h>
+
+@class SPTDataLoaderService;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SPTDataLoaderServiceEventObserver <NSObject>
+
+/**
+ Called when the underlying background URL session notifies about finishing background events.
+ 
+ @discussion This method will only be called if a background session is used to handle some of the requests. To achieve
+ that, set the request background policy to @c SPTDataLoaderRequestBackgroundPolicyAlways and configure the service to
+ work in background.
+ */
+- (void)dataLoaderServiceDidFinishBackgroundEvents:(SPTDataLoaderService *)dataLoaderService __OSX_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
**What has changed**
I added another type of observers to the data loader service for getting notification about background URL session events.
I tried to make it similar to the consumption observer pattern which is already there, although I'm not sure the queue parameter is actually needed for this case. Let me know if this makes sense!

**Why this was changed**
`- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session` is called during a background refresh, when a URL session has notified its delegate about all updates to the tasks it was handling. See [documentation](https://developer.apple.com/documentation/foundation/nsurlsessiondelegate/1617185-urlsessiondidfinisheventsforback) for more info.