### PR TITLE
Fix coverage, segment per-platform

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,9 @@
 coverage:
   ignore:
   - build
-  - Carthage
   - demo
   - other
-  - SPTDataLoaderTests
+  - Tests
   status:
     patch:
       default:


### PR DESCRIPTION
Fix codecov ignores to ignore tests.

Build for testing into different derived data paths per-platform. Right now, the "last in wins" so we only get information for the last test target that ran in CI. This changes it to invoke codecov once per-platform and adds the `-F` flag to tag them as such.

This PR will probably fail the coverage check because of the large delta, but subsequent PRs should be a little happier.