### PR TITLE
Bump to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file. SPTDataLoad
 
 --
 
+## [2.1.0](https://github.com/spotify/SPTDataLoader/releases/tag/2.1.0)
+_Released on 2021-02-16._
+
+### Added
+* Added SPTDataLoaderBlockWrapper callback API
+* Added SPTDataLoaderSwift overlay
+* Added Xcode 12 support
+
+### Changed
+* Changed Accept-Language header to remove duplicates
+* Changed modules to be disabled by default for static library and test targets
+
 ## [2.0.0](https://github.com/spotify/SPTDataLoader/releases/tag/2.0.0)
 _Released on 2020-07-23._
 

--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Spotify. All rights reserved.</string>
+	<string>Copyright © 2021 Spotify. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Framework/SPTDataLoader.h
+++ b/Framework/SPTDataLoader.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/SPTDataLoader.podspec
+++ b/SPTDataLoader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = "SPTDataLoader"
-    s.version      = "2.0.0"
+    s.version      = "2.1.0"
     s.summary      = "SPTDataLoader is Spotify’s HTTP library for Objective-C"
 
     s.description  = <<-DESC
@@ -23,12 +23,29 @@ Pod::Spec.new do |s|
         "Will Sackfield" => "sackfield@spotify.com"
     }
 
-    s.source                = { :git => "https://github.com/spotify/SPTDataLoader.git", :tag => s.version }
-    s.source_files          = "include/SPTDataLoader/*.h", "SPTDataLoader/*.{h,m}"
-    s.public_header_files   = "include/SPTDataLoader/*.h"
-    s.framework             = "Security"
-    s.xcconfig              = {
-        "OTHER_LDFLAGS" => "-lObjC"
-    }
+    s.source           = { :git => "https://github.com/spotify/SPTDataLoader.git", :tag => s.version }
+    s.swift_version    = "5.1"
+
+    s.default_subspec  = "Core"
+
+    s.subspec "Core" do |sp|
+        sp.source_files         = "include/SPTDataLoader/*.h", "Sources/SPTDataLoader/*.{h,m}"
+        sp.public_header_files  = "include/SPTDataLoader/*.h"
+        sp.framework            = "Security"
+        sp.xcconfig             = {
+            "OTHER_LDFLAGS" => "-lObjC"
+        }
+    end
+
+    s.subspec "Swift" do |sp|
+        sp.dependency "SPTDataLoader/Core"
+
+        sp.source_files  = "Sources/SPTDataLoaderSwift/**/*.swift"
+
+        sp.ios.deployment_target      = "10.0"
+        sp.osx.deployment_target      = "10.12"
+        sp.tvos.deployment_target     = "10.0"
+        sp.watchos.deployment_target  = "3.0"
+    end
 
 end

--- a/Sources/SPTDataLoader/NSDictionary+HeaderSize.h
+++ b/Sources/SPTDataLoader/NSDictionary+HeaderSize.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/NSDictionary+HeaderSize.m
+++ b/Sources/SPTDataLoader/NSDictionary+HeaderSize.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoader.m
+++ b/Sources/SPTDataLoader/SPTDataLoader.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderBlockWrapper.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderExponentialTimer.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderExponentialTimer.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderFactory+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderFactory+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderFactory.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderImplementation+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderImplementation+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRateLimiter+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRateLimiter+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRateLimiter.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRateLimiter.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRequest+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequest+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderResolver.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolver.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderResponse+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderResponse+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResponse.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderService+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderService+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderService.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProvider.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProvider.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/DataLoader.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoader.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/DataLoaderError.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderError.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/Request.swift
+++ b/Sources/SPTDataLoaderSwift/Request.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/Response.swift
+++ b/Sources/SPTDataLoaderSwift/Response.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/ResponseDecoder.swift
+++ b/Sources/SPTDataLoaderSwift/ResponseDecoder.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
+++ b/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/SPTDataLoader.swift
+++ b/Sources/SPTDataLoaderSwift/SPTDataLoader.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/Utilities/AccessLock.swift
+++ b/Sources/SPTDataLoaderSwift/Utilities/AccessLock.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Sources/SPTDataLoaderSwift/Utilities/Result+Convenience.swift
+++ b/Sources/SPTDataLoaderSwift/Utilities/Result+Convenience.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/NSDictionaryHeaderSizeTest.m
+++ b/Tests/SPTDataLoader/NSDictionaryHeaderSizeTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderBlockWrapperTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderBlockWrapperTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenImplementationTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderExponentialTimerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderExponentialTimerTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderFactoryTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderFactoryTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderRateLimiterTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRateLimiterTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderResolverAddressTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResolverAddressTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderResolverTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResolverTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderServerTrustPolicyTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServerTrustPolicyTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/SPTDataLoaderTimeProviderImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderTimeProviderImplementationTest.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSBundleMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSBundleMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSBundleMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSBundleMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSDataMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSDataMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSDataMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSDataMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSFileManagerMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSFileManagerMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSFileManagerMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSFileManagerMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/RequestTest.swift
+++ b/Tests/SPTDataLoaderSwift/RequestTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/ResponseTest.swift
+++ b/Tests/SPTDataLoaderSwift/ResponseTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/SPTDataLoaderFactoryConvenienceTest.swift
+++ b/Tests/SPTDataLoaderSwift/SPTDataLoaderFactoryConvenienceTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/Utilities/FakeDataLoaderResponse.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/FakeDataLoaderResponse.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/Tests/SPTDataLoaderSwift/Utilities/StubbedNetwork.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/StubbedNetwork.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/ci/expected_license_header.txt
+++ b/ci/expected_license_header.txt
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/ci/spotify_os.xcconfig
+++ b/ci/spotify_os.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Spotify AB.
+// Copyright (c) 2015-2021 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/ci/validate_license_conformance.sh
+++ b/ci/validate_license_conformance.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2015-2020 Spotify AB.
+# Copyright (c) 2015-2021 Spotify AB.
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/demo/AppDelegate.h
+++ b/demo/AppDelegate.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/AppDelegate.m
+++ b/demo/AppDelegate.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/Base.lproj/LaunchScreen.xib
+++ b/demo/Base.lproj/LaunchScreen.xib
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2020 Spotify. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2021 Spotify. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/demo/ClientKeys.h
+++ b/demo/ClientKeys.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/NSString+OAuthBlob.h
+++ b/demo/NSString+OAuthBlob.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/NSString+OAuthBlob.m
+++ b/demo/NSString+OAuthBlob.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/PlaylistsViewController.h
+++ b/demo/PlaylistsViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/PlaylistsViewController.m
+++ b/demo/PlaylistsViewController.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/PlaylistsViewModel.h
+++ b/demo/PlaylistsViewModel.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/PlaylistsViewModel.m
+++ b/demo/PlaylistsViewModel.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/SPTDataLoaderAuthoriserOAuth.h
+++ b/demo/SPTDataLoaderAuthoriserOAuth.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/SPTDataLoaderAuthoriserOAuth.m
+++ b/demo/SPTDataLoaderAuthoriserOAuth.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/ViewController.h
+++ b/demo/ViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/ViewController.m
+++ b/demo/ViewController.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/demo/main.m
+++ b/demo/main.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
+++ b/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
+++ b/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
+++ b/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
+++ b/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
+++ b/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderFactory.h
+++ b/include/SPTDataLoader/SPTDataLoaderFactory.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderImplementation.h
+++ b/include/SPTDataLoader/SPTDataLoaderImplementation.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
+++ b/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderResolver.h
+++ b/include/SPTDataLoader/SPTDataLoaderResolver.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderServerTrustPolicy.h
+++ b/include/SPTDataLoader/SPTDataLoaderServerTrustPolicy.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015-2020 Spotify AB.
+ Copyright (c) 2015-2021 Spotify AB.
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
- Updated version number and changelog
- Updated dates to include current year
- Updated Podspec to provide optional Swift overlay