### PR TITLE
Swift: Add active request convenience methods

### DIFF
--- a/Sources/SPTDataLoaderSwift/DataLoader.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoader.swift
@@ -23,11 +23,17 @@ import Foundation
 
 /// A protocol that provides data request handling.
 public protocol DataLoader {
+    /// The executed requests currently awaiting a response.
+    var activeRequests: [Request] { get }
+
     /// Creates a `Request` that can be used to retrieve the contents of a URL.
     /// - Parameter url: The `URL` for the request.
     /// - Parameter sourceIdentifier: The identifier for the request source. May be `nil`.
     /// - Returns: A new `Request` instance.
     func request(_ url: URL, sourceIdentifier: String?) -> Request
+
+    /// Cancels all requests that have been executed and are awaiting a response.
+    func cancelActiveRequests()
 }
 
 public extension SPTDataLoaderFactory {

--- a/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
@@ -35,6 +35,8 @@ final class DataLoaderWrapper: NSObject {
 // MARK: - DataLoader
 
 extension DataLoaderWrapper: DataLoader {
+    var activeRequests: [Request] { accessLock.sync { Array(requests.values) } }
+
     func request(_ url: URL, sourceIdentifier: String?) -> Request {
         let sptRequest = SPTDataLoaderRequest(url: url, sourceIdentifier: sourceIdentifier)
         let request = Request(request: sptRequest) { [weak self] request in
@@ -50,6 +52,17 @@ extension DataLoaderWrapper: DataLoader {
         }
 
         return request
+    }
+
+    func cancelActiveRequests() {
+        var activeRequests: [Request] = []
+
+        accessLock.sync {
+            activeRequests.append(contentsOf: requests.values)
+            requests.removeAll()
+        }
+
+        activeRequests.forEach { request in request.cancel() }
     }
 }
 

--- a/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
@@ -40,6 +40,29 @@ class DataLoaderWrapperTest: XCTestCase {
         stubbedNetwork.removeAllStubs()
     }
 
+    // MARK: Active Tests
+
+    func test_activeRequests_shouldProvideExecutingRequests_whenRequested() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://foo.bar/baz.json"))
+        let request1 = dataLoaderWrapper.request(url, sourceIdentifier: "foo")
+        let request2 = dataLoaderWrapper.request(url, sourceIdentifier: "bar")
+        let request3 = dataLoaderWrapper.request(url, sourceIdentifier: "baz")
+
+        stubbedNetwork.addStub(where: { $0.url == url })
+
+        // When
+        request1.response { _ in }
+        request2.response { _ in }
+        let requests = dataLoaderWrapper.activeRequests
+
+        // Then
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertTrue(requests.contains(where: { $0 === request1 }))
+        XCTAssertTrue(requests.contains(where: { $0 === request2 }))
+        XCTAssertFalse(requests.contains(where: { $0 === request3 }))
+    }
+
     // MARK: Request Tests
 
     func test_request_shouldReceiveCallback_whenSuccessReceived() throws {
@@ -89,6 +112,33 @@ class DataLoaderWrapperTest: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5)
+    }
+
+    // MARK: Cancel Tests
+
+    func test_cancelActiveRequests_shouldNotReceiveCallbacks_whenExecuted() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://foo.bar/baz.json"))
+        let request1 = dataLoaderWrapper.request(url, sourceIdentifier: "foo")
+        let request2 = dataLoaderWrapper.request(url, sourceIdentifier: "bar")
+        let request3 = dataLoaderWrapper.request(url, sourceIdentifier: "baz")
+
+        stubbedNetwork.addStub(where: { $0.url == url })
+
+        // When
+        let responseExpectation = expectation(description: "Response not expected")
+        responseExpectation.isInverted = true
+
+        request1.response { _ in responseExpectation.fulfill() }
+        request2.response { _ in responseExpectation.fulfill() }
+        dataLoaderWrapper.cancelActiveRequests()
+
+        // Then
+        waitForExpectations(timeout: 0.5) { _ in
+            XCTAssertTrue(request1.isCancelled)
+            XCTAssertTrue(request2.isCancelled)
+            XCTAssertFalse(request3.isCancelled)
+        }
     }
 }
 


### PR DESCRIPTION
Provides convenience methods for obtaining and cancelling active requests, similar to those of the underlying `SPTDataLoader`.

cc @zvonicek 