### PR TITLE
Swift: Add status code response validator

### DIFF
--- a/Sources/SPTDataLoaderSwift/DataLoaderError.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderError.swift
@@ -23,3 +23,9 @@ public enum ResponseSerializationError: Error {
     /// The data was expected but a null value was provided.
     case dataNotFound
 }
+
+/// An error that occurs during response validation.
+public enum ResponseValidationError: Error {
+    /// The status code was not within the accepted codes.
+    case badStatusCode(code: Int)
+}

--- a/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
+++ b/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
@@ -28,10 +28,6 @@ public protocol ResponseSerializer {
 
 struct DataResponseSerializer: ResponseSerializer {
     func serialize(response: SPTDataLoaderResponse) throws -> Data {
-        guard response.error == nil else {
-            throw response.error.unsafelyUnwrapped
-        }
-
         guard let data = response.body else {
             throw ResponseSerializationError.dataNotFound
         }
@@ -44,10 +40,6 @@ struct DecodableResponseSerializer<Value: Decodable>: ResponseSerializer {
     let decoder: ResponseDecoder
 
     func serialize(response: SPTDataLoaderResponse) throws -> Value {
-        guard response.error == nil else {
-            throw response.error.unsafelyUnwrapped
-        }
-
         guard let data = response.body else {
             throw ResponseSerializationError.dataNotFound
         }
@@ -60,10 +52,6 @@ struct JSONResponseSerializer: ResponseSerializer {
     let options: JSONSerialization.ReadingOptions
 
     func serialize(response: SPTDataLoaderResponse) throws -> Any {
-        guard response.error == nil else {
-            throw response.error.unsafelyUnwrapped
-        }
-
         guard let data = response.body else {
             throw ResponseSerializationError.dataNotFound
         }

--- a/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
@@ -18,23 +18,6 @@ import Foundation
 import XCTest
 
 class DataResponseSerializerTest: XCTestCase {
-    func test_responseSerialization_shouldFail_whenErrorIsPresent() {
-        // Given
-        let request = SPTDataLoaderRequest()
-        let responseError = NSError(domain: "foo", code: 123, userInfo: nil)
-        let responseFake = FakeDataLoaderResponse(request: request, error: responseError)
-
-        // When
-        let serializer = DataResponseSerializer()
-        let result = Result { try serializer.serialize(response: responseFake) }
-
-        // Then
-        guard case .failure(let error) = result else {
-            return XCTFail("Expected failure result")
-        }
-        XCTAssertEqual(error as NSError, responseError)
-    }
-
     func test_responseSerialization_shouldBeSuccessful_whenBodyIsMissing() {
         // Given
         let request = SPTDataLoaderRequest()

--- a/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
@@ -18,22 +18,6 @@ import Foundation
 import XCTest
 
 class DecodableResponseSerializerTest: XCTestCase {
-    func test_responseSerialization_shouldFail_whenErrorIsPresent() {
-        // Given
-        let request = SPTDataLoaderRequest()
-        let responseFake = FakeDataLoaderResponse(request: request, error: TestError.foo)
-
-        // When
-        let decoder = JSONDecoder()
-        let serializer = DecodableResponseSerializer<TestDecodable>(decoder: decoder)
-        let result = Result { try serializer.serialize(response: responseFake) }
-
-        // Then
-        guard case .failure(let error) = result else {
-            return XCTFail("Expected failure result")
-        }
-        XCTAssertTrue(error is TestError)
-    }
 
     func test_responseSerialization_shouldBeUnsuccessful_whenBodyIsMissing() {
         // Given

--- a/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
@@ -18,22 +18,6 @@ import Foundation
 import XCTest
 
 class JSONResponseSerializerTest: XCTestCase {
-    func test_responseSerialization_shouldFail_whenErrorIsPresent() {
-        // Given
-        let request = SPTDataLoaderRequest()
-        let responseFake = FakeDataLoaderResponse(request: request, error: TestError.foo)
-
-        // When
-        let serializer = JSONResponseSerializer(options: [])
-        let result = Result { try serializer.serialize(response: responseFake) }
-
-        // Then
-        guard case .failure(let error) = result else {
-            return XCTFail("Expected failure result")
-        }
-        XCTAssertTrue(error is TestError)
-    }
-
     func test_responseSerialization_shouldBeUnsuccessful_whenBodyIsMissing() {
         // Given
         let request = SPTDataLoaderRequest()


### PR DESCRIPTION
Adds status code response validators to make it easier to enforce the same `response.result` behavior as pre-#212.

Removes serializer `response.error` forwarding because serializers do not run if an error has already occurred, so this code was not really doing anything.