### PR TITLE
Fix invalid response body on retried request

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -235,7 +235,8 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
         }
         return;
     }
-    
+
+    self.receivedData = nil;
     self.absoluteStartTime = CFAbsoluteTimeGetCurrent();
     [self.task resume];
 }

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -128,7 +128,7 @@
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
 
     self.handler.retryQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Retry limit equals maximum retry count"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Request was retried once"];
     __weak __typeof(self) weakSelf = self;
     self.task.resumeCallback = ^ {
         __strong __typeof(self) strongSelf = weakSelf;

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -121,6 +121,41 @@
     XCTAssertEqual(self.requestResponseHandler.numberOfFailedResponseCalls, 0u, @"The handler did relay a failed response onto its request response handler when it should have silently retried");
 }
 
+- (void)testRetryWithResponseBody
+{
+    NSData *errorData = [@"error payload" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *successData = [@"success payload" dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
+
+    self.handler.retryQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Retry limit equals maximum retry count"];
+    __weak __typeof(self) weakSelf = self;
+    self.task.resumeCallback = ^ {
+        __strong __typeof(self) strongSelf = weakSelf;
+        [strongSelf.handler receiveResponse:[NSURLResponse new]];
+
+        if (strongSelf.handler.retryCount == 0) {
+            // Let the first request fail
+            [strongSelf.handler receiveData:errorData];
+            SPTDataLoaderResponse *response = [strongSelf.handler completeWithError:error];
+
+            // When the request gets retried the response should be nil
+            XCTAssertNil(response);
+        } else {
+            // Let the second (retried) request succeed
+            [strongSelf.handler receiveData:successData];
+            SPTDataLoaderResponse *response = [strongSelf.handler completeWithError:nil];
+            XCTAssert([response.body isEqual:successData]);
+
+            [expectation fulfill];
+        }
+    };
+
+    self.request.maximumRetryCount = 1;
+    [self.handler start];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
 - (void)testDataCreationWithContentLengthFromResponse
 {
     // It's times like these... I wish I had the SPTSingletonSwizzler ;)


### PR DESCRIPTION
This PR fixes a bug in retry mechanism of Objective-C-based SPTDataLoader. The bug appears when the retry count is greater than zero, one or more initial requests fail with non-empty payload (such human-readable error message) and n-th request finally succeeds with non-empty payload. In this case the payload contains all the previous payloads prepended to the succeeding payload.

This can be fixed by strictly _nil_-ing the `receivedData` property before a request (no matter if initial or retried) starts.