### PR TITLE
Correct errorPtr usage in NSDataMock

### DIFF
--- a/Tests/SPTDataLoader/Utilities/NSDataMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSDataMock.m
@@ -22,7 +22,6 @@
                                     options:(NSDataReadingOptions)readOptionsMask
                                       error:(NSError * __autoreleasing * _Nullable)errorPtr
 {
-    errorPtr = nil;
     return [path dataUsingEncoding:NSUTF8StringEncoding];
 }
 


### PR DESCRIPTION
Fixes Xcode 13.3 build error: `Parameter 'errorPtr' set but not used`

SeeAlso: [Creating and Returning NSError Objects](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html#//apple_ref/doc/uid/TP40001806-CH204-SW5)