### PR TITLE
Change `@available` in Request+Concurrency

### DIFF
--- a/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
+++ b/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Request {
     func task() -> ResponseTask<Void> {
         return ResponseTask(request: self)
@@ -41,7 +41,7 @@ public extension Request {
 
 // MARK: -
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct ResponseTask<Value> {
     private let task: Task<Response<Value, Error>, Never>
 
@@ -74,7 +74,7 @@ public struct ResponseTask<Value> {
     }
 }
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 private extension ResponseTask {
     init(request: Request) where Value == Void {
         self.init(request: request) { continuation in

--- a/Tests/SPTDataLoaderSwift/Request+ConcurrencyTest.swift
+++ b/Tests/SPTDataLoaderSwift/Request+ConcurrencyTest.swift
@@ -19,7 +19,7 @@
 import Foundation
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class Request_ResponseTaskTest: XCTestCase {
     private actor ResponseActor<Value> {
         var value: Value?


### PR DESCRIPTION
With the release of Xcode 13.2, swift concurrency can now be used on:
 - macOS Catalina 10.15
 - iOS 13
 - tvOS 13
 - watchOS 6


https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes
> You can now use Swift Concurrency in applications that deploy to macOS Catalina 10.15, iOS 13, tvOS 13, and watchOS 6 or newer. This support includes async/await, actors, global actors, structured concurrency, and the task APIs. (70738378)