### PR TITLE
Don't use enumerateByteRangesUsingBlock

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -97,20 +97,15 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 
 - (void)receiveData:(NSData *)data
 {
-    [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *stop) {
-        
-        NSData *dataRange = [NSData dataWithBytes:bytes length:byteRange.length];
-
-        if (self.request.chunks) {
-            [self.requestResponseHandler receivedDataChunk:dataRange forResponse:self.response];
+    if (self.request.chunks) {
+        [self.requestResponseHandler receivedDataChunk:data forResponse:self.response];
+    } else {
+        if (!self.receivedData) {
+            self.receivedData = [data mutableCopy];
         } else {
-            if (!self.receivedData) {
-                self.receivedData = [dataRange mutableCopy];
-            } else {
-                [self.receivedData appendData:dataRange];
-            }
+            [self.receivedData appendData:data];
         }
-    }];
+    }
 }
 
 - (nullable SPTDataLoaderResponse *)completeWithError:(nullable NSError *)error


### PR DESCRIPTION
This is basically a revert for
https://github.com/spotify/SPTDataLoader/commit/844112c2a56adcf5889af91b49ebd1ad21befe17

It is actually not clear how enumerateByteRangesUsingBlock can fix any
crash there but on the other hand is causing unnecessary callback and
delay in data delivering.