### PR TITLE
Allow performing requests for URLs that do not contain a host

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderService.m
@@ -207,27 +207,25 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)performRequest:(SPTDataLoaderRequest *)request
 requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
 {
-    if (request.cancellationToken.cancelled) {
+    if (request.URL == nil || request.cancellationToken.cancelled) {
         return;
     }
-    
-    if (request.URL.host == nil) {
-        return;
-    }
-    
-    NSString *host = [self.resolver addressForHost:(NSString * _Nonnull)request.URL.host];
-    NSString *requestHost = request.URL.host;
-    if (![host isEqualToString:requestHost] && host) {
-        NSURLComponents *requestComponents = [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
-        requestComponents.host = host;
-        
-        NSURL *URL = requestComponents.URL;
-        
-        if (URL == nil) {
-            return;
+
+    if (request.URL.host != nil && self.resolver != nil) {
+        NSString *requestHost = request.URL.host;
+        NSString *hostAddress = [self.resolver addressForHost:requestHost];
+        if (![hostAddress isEqualToString:requestHost]) {
+            NSURLComponents *requestComponents = [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
+            requestComponents.host = hostAddress;
+
+            NSURL *URL = requestComponents.URL;
+
+            if (URL == nil) {
+                return;
+            }
+
+            request.URL = URL;
         }
-        
-        request.URL = URL;
     }
 
     NSURLSession *session = [self.sessionSelector URLSessionForRequest:request];

--- a/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
@@ -729,4 +729,24 @@
     XCTAssertEqual(requestResponseHandlerMock.numberOfNewBodyStreamCalls, 1u, @"The service did not forward the prompt for a new body stream to the request response handler");
 }
 
+- (void)testRequestingFileURL
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL fileURLWithPath:@"/tmp/foo/bar.tmp"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    XCTAssertNotNil(self.session.lastDataTask);
+    XCTAssertEqualObjects(request.URL, URL);
+}
+
+- (void)testRequestingDataURL
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    XCTAssertNotNil(self.session.lastDataTask);
+    XCTAssertEqualObjects(request.URL, URL);
+}
+
 @end


### PR DESCRIPTION
Certain URL types [supported](https://developer.apple.com/documentation/foundation/nsurlsession?language=objc#2934752) by `NSURLSession` are valid even though they do not contain a `host` property. Previously, the data loader would not even attempt to request these URLs. With this change it is possible to load local files as well as data URIs.