### PR TITLE
Add spotify OSS maintainer metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: SPTDataLoader
+spec:
+  type: library
+  owner: ratatosk


### PR DESCRIPTION
This is needed to internally track who owns this open-source project.