### PR TITLE
Swift: Add decodable response type parameter

### DIFF
--- a/Sources/SPTDataLoaderSwift/Request+Combine.swift
+++ b/Sources/SPTDataLoaderSwift/Request+Combine.swift
@@ -27,8 +27,11 @@ public extension Request {
         return ResponsePublisher(request: self)
     }
 
-    func decodablePublisher<Value: Decodable>(decoder: ResponseDecoder = JSONDecoder()) -> ResponsePublisher<Value> {
-        return ResponsePublisher(request: self, decoder: decoder)
+    func decodablePublisher<Value: Decodable>(
+        type: Value.Type = Value.self,
+        decoder: ResponseDecoder = JSONDecoder()
+    ) -> ResponsePublisher<Value> {
+        return ResponsePublisher(request: self, decodableType: type, decoder: decoder)
     }
 
     func jsonPublisher(options: JSONSerialization.ReadingOptions = []) -> ResponsePublisher<Any> {
@@ -87,9 +90,9 @@ private extension ResponsePublisher {
         }
     }
 
-    init(request: Request, decoder: ResponseDecoder) where Value: Decodable {
+    init(request: Request, decodableType: Value.Type, decoder: ResponseDecoder) where Value: Decodable {
         self.init(request: request) { completion in
-            request.responseDecodable(decoder: decoder, completionHandler: completion)
+            request.responseDecodable(type: decodableType, decoder: decoder, completionHandler: completion)
         }
     }
 

--- a/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
+++ b/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
@@ -26,8 +26,11 @@ public extension Request {
         return ResponseTask(request: self)
     }
 
-    func decodableTask<Value: Decodable>(decoder: ResponseDecoder = JSONDecoder()) -> ResponseTask<Value> {
-        return ResponseTask(request: self, decoder: decoder)
+    func decodableTask<Value: Decodable>(
+        type: Value.Type = Value.self,
+        decoder: ResponseDecoder = JSONDecoder()
+    ) -> ResponseTask<Value> {
+        return ResponseTask(request: self, decodableType: type, decoder: decoder)
     }
 
     func jsonTask(options: JSONSerialization.ReadingOptions = []) -> ResponseTask<Any> {
@@ -94,9 +97,9 @@ private extension ResponseTask {
         }
     }
 
-    init(request: Request, decoder: ResponseDecoder) where Value: Decodable {
+    init(request: Request, decodableType: Value.Type, decoder: ResponseDecoder) where Value: Decodable {
         self.init(request: request) { continuation in
-            request.responseDecodable(decoder: decoder) { response in
+            request.responseDecodable(type: decodableType, decoder: decoder) { response in
                 continuation.resume(returning: response)
             }
         }

--- a/Sources/SPTDataLoaderSwift/Request.swift
+++ b/Sources/SPTDataLoaderSwift/Request.swift
@@ -272,6 +272,7 @@ public extension Request {
     /// - Parameter completionHandler: The callback closure invoked upon completion.
     @discardableResult
     func responseDecodable<Value: Decodable>(
+        type: Value.Type = Value.self,
         decoder: ResponseDecoder = JSONDecoder(),
         completionHandler: @escaping (Response<Value, Error>) -> Void
     ) -> Self {


### PR DESCRIPTION
Follows the common convention of including a type parameter, allowing the API call site to read a little nicer in cases where the response type cannot be inferred (or needs to differ from what's inferred).

Example:
```swift
struct SomeDecodable: Decodable {
  let value: Bool
}

// Before
responseDecodable { (response: Response<SomeDecodable, Error>) in
  methodAcceptingOptionalBool(response.result.success?.value)
}

// After
responseDecodable(type: SomeDecodable.self) { response in
  methodAcceptingOptionalBool(response.result.success?.value)
}
```