### PR TITLE
Add shouldStopRedirection to SPTDataLoaderRequest

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequest.m
@@ -207,6 +207,7 @@ static NSString * NSStringFromSPTDataLoaderRequestMethod(SPTDataLoaderRequestMet
     copy.timeout = self.timeout;
     copy.cancellationToken = self.cancellationToken;
     copy.bodyStream = self.bodyStream;
+    copy.shouldStopRedirection = self.shouldStopRedirection;
     return copy;
 }
 

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -50,6 +50,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 @property (nonatomic, assign) BOOL calledCancelledRequest;
 @property (nonatomic, assign) BOOL started;
 @property (nonatomic, strong, readwrite) dispatch_queue_t retryQueue;
+@property (nonatomic, assign) BOOL shouldStopRedirection;
 
 @end
 
@@ -82,6 +83,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
         _request = request;
         _requestResponseHandler = requestResponseHandler;
         _rateLimiter = rateLimiter;
+        _shouldStopRedirection = request.shouldStopRedirection;
 
         __weak __typeof(self) weakSelf = self;
         _executionBlock = ^{
@@ -179,7 +181,7 @@ static NSUInteger const SPTDataLoaderRequestTaskHandlerMaxRedirects = 10;
 - (BOOL)mayRedirect
 {
     // Limit the amount of possible redirects
-    if (++self.redirectCount > SPTDataLoaderRequestTaskHandlerMaxRedirects) {
+    if (++self.redirectCount > SPTDataLoaderRequestTaskHandlerMaxRedirects || self.shouldStopRedirection) {
         return NO;
     }
 

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -262,4 +262,20 @@
     XCTAssertEqualObjects([dataString stringByAppendingString:dataString], receivedString);
 }
 
+- (void)testMayRedirectInitially
+{
+    XCTAssertTrue(self.handler.mayRedirect);
+}
+
+- (void)testMayNotRedirect
+{
+    self.request.shouldStopRedirection = YES;
+    self.handler = [SPTDataLoaderRequestTaskHandler dataLoaderRequestTaskHandlerWithTask:self.task
+                                                                                 request:self.request
+                                                                  requestResponseHandler:self.requestResponseHandler
+                                                                             rateLimiter:self.rateLimiter];
+    XCTAssertFalse(self.handler.mayRedirect);
+
+}
+
 @end

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
@@ -57,6 +57,11 @@
     XCTAssertEqualObjects(self.request.headers, @{}, @"The headers should be empty when initially setting up the request");
 }
 
+- (void)testShouldStopRedirectionNoInitially
+{
+    XCTAssertFalse(self.request.shouldStopRedirection, @"The shouldStopRedirection should be NO when initially setting up the request");
+}
+
 - (void)testAddValueToNilHeader
 {
 #pragma clang diagnostic push
@@ -132,6 +137,7 @@
     self.request.method = SPTDataLoaderRequestMethodPost;
     self.request.backgroundPolicy = SPTDataLoaderRequestBackgroundPolicyAlways;
     self.request.bodyStream = inputStream;
+    self.request.shouldStopRedirection = YES;
     SPTDataLoaderRequest *request = [self.request copy];
     XCTAssertEqual(request.maximumRetryCount, self.request.maximumRetryCount, @"The retry count was not copied correctly");
     XCTAssertEqualObjects(request.body, self.request.body, @"The body was not copied correctly");
@@ -142,6 +148,7 @@
     XCTAssertEqual(request.method, self.request.method, @"The method was not copied correctly");
     XCTAssertEqual(request.backgroundPolicy, self.request.backgroundPolicy, @"The background policy was not copied correctly");
     XCTAssertEqual(request.bodyStream, self.request.bodyStream, @"The body stream was not copied correctly");
+    XCTAssertEqual(request.shouldStopRedirection, self.request.shouldStopRedirection, @"The stop redirection was not copied correctly");
 }
 
 - (void)testAcceptLanguageWithNoEnglishLanguages

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -121,6 +121,11 @@ typedef NS_ENUM(NSInteger, SPTDataLoaderRequestBackgroundPolicy) {
  @discussion This is used for logging purposes to locate where data is downloaded from.
  */
 @property (nonatomic, copy, nullable) NSString *sourceIdentifier;
+/**
+ A Boolean value that indicates whether the redirection should happen for a request.
+ @discussion default is NO.
+ */
+@property (nonatomic, assign) BOOL shouldStopRedirection;
 
 /**
  Class constructor


### PR DESCRIPTION

### What has changed
- Add a bool `shouldStopRedirection` to `SPTDataLoaderRequest`

### Why this was changed
- Currently url redirection happens automatically when using SPTDataLoader. To give user more control over the http url redirection a bool `shouldStopRedirection` is added to `SPTDataLoaderRequest`. 