### PR TITLE
Add optional crash reporter

### DIFF
--- a/Framework/SPTDataLoader.h
+++ b/Framework/SPTDataLoader.h
@@ -17,6 +17,7 @@
 #import <SPTDataLoader/SPTDataLoaderAuthoriser.h>
 #import <SPTDataLoader/SPTDataLoaderCancellationToken.h>
 #import <SPTDataLoader/SPTDataLoaderConsumptionObserver.h>
+#import <SPTDataLoader/SPTDataLoaderCrashReporter.h>
 #import <SPTDataLoader/SPTDataLoaderDelegate.h>
 #import <SPTDataLoader/SPTDataLoaderExponentialTimer.h>
 #import <SPTDataLoader/SPTDataLoaderFactory.h>

--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		48E7EEC62059288F00BB7CCC /* NSDataMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E7EEC52059288F00BB7CCC /* NSDataMock.m */; };
 		6994E68C1EE9F72600128CDE /* certs-google.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68B1EE9F49B00128CDE /* certs-google.bundle */; };
 		6994E68D1EE9F72800128CDE /* certs-spotify.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68A1EE9F49B00128CDE /* certs-spotify.bundle */; };
+		E081EDD7299F84A60080268B /* SPTDataLoaderCrashReporterMock.m in Sources */ = {isa = PBXBuildFile; fileRef = E081EDD6299F84A60080268B /* SPTDataLoaderCrashReporterMock.m */; };
 		EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */; };
 		F50DEF6927CEA8910024B526 /* Request+CombineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DEF6827CEA8910024B526 /* Request+CombineTest.swift */; };
 		F50DEF6B27CEA8990024B526 /* Request+ConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DEF6A27CEA8990024B526 /* Request+ConcurrencyTest.swift */; };
@@ -224,6 +225,9 @@
 		8247036C1BEA021C0027DE04 /* SPTDataLoaderCancellationTokenFactoryImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCancellationTokenFactoryImplementation.h; sourceTree = "<group>"; };
 		C6515CF31BA2D4AF00271211 /* SPTDataLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoader.h; sourceTree = "<group>"; };
 		C6515CF41BA2D4C200271211 /* SPTDataLoaderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderDelegate.h; sourceTree = "<group>"; };
+		E081EDD5299F84A60080268B /* SPTDataLoaderCrashReporterMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCrashReporterMock.h; sourceTree = "<group>"; };
+		E081EDD6299F84A60080268B /* SPTDataLoaderCrashReporterMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderCrashReporterMock.m; sourceTree = "<group>"; };
+		E0946963299F89D700712516 /* SPTDataLoaderCrashReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderCrashReporter.h; sourceTree = "<group>"; };
 		EAC45A751C0F4633009AA9F9 /* NSURLSessionDataTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDataTaskMock.h; sourceTree = "<group>"; };
 		EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDataTaskMock.m; sourceTree = "<group>"; };
 		F50DEF6827CEA8910024B526 /* Request+CombineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+CombineTest.swift"; sourceTree = "<group>"; };
@@ -355,6 +359,7 @@
 				C6515CF31BA2D4AF00271211 /* SPTDataLoader.h */,
 				056A04B41A13D10900FA72AD /* SPTDataLoaderAuthoriser.h */,
 				056A04AF1A13D10900FA72AD /* SPTDataLoaderCancellationToken.h */,
+				E0946963299F89D700712516 /* SPTDataLoaderCrashReporter.h */,
 				051937541A273278006ABB3E /* SPTDataLoaderConsumptionObserver.h */,
 				C6515CF41BA2D4C200271211 /* SPTDataLoaderDelegate.h */,
 				056A04B91A13D10900FA72AD /* SPTDataLoaderExponentialTimer.h */,
@@ -529,6 +534,8 @@
 				2DE3DAC92344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.m */,
 				430D3C85249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.h */,
 				430D3C86249CDD8500791FD3 /* SPTDataLoaderTimeProviderMock.m */,
+				E081EDD5299F84A60080268B /* SPTDataLoaderCrashReporterMock.h */,
+				E081EDD6299F84A60080268B /* SPTDataLoaderCrashReporterMock.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -731,6 +738,7 @@
 				056A04BE1A13D48B00FA72AD /* SPTDataLoaderServiceTest.m in Sources */,
 				059940A91A150C90006D6BE9 /* SPTDataLoaderResponseTest.m in Sources */,
 				48E7EEC320591A3000BB7CCC /* NSFileManagerMock.m in Sources */,
+				E081EDD7299F84A60080268B /* SPTDataLoaderCrashReporterMock.m in Sources */,
 				F7346A6E1CC2DEAA00B8AB41 /* SPTDataLoaderServerTrustPolicyTest.m in Sources */,
 				059940A71A150275006D6BE9 /* SPTDataLoaderRequestTest.m in Sources */,
 				0599409D1A14F32A006D6BE9 /* SPTDataLoaderRequestResponseHandlerDelegateMock.m in Sources */,

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCrashReporterMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCrashReporterMock.h
@@ -1,0 +1,27 @@
+/*
+ Copyright 2015-2022 Spotify AB
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "SPTDataLoaderCrashReporter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderCrashReporterMock : NSObject<SPTDataLoaderCrashReporter>
+
+@property (nonatomic, assign) NSInteger numberOfCallsToLeaveBreadcrumb;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCrashReporterMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCrashReporterMock.m
@@ -1,0 +1,17 @@
+//
+//  SPTDataLoaderCrashReporterMock.m
+//  SPTDataLoaderTests
+//
+//  Created by Gabriel Andreatto on 2023-02-17.
+//  Copyright © 2023 Spotify. All rights reserved.
+//
+
+#import "SPTDataLoaderCrashReporterMock.h"
+
+@implementation SPTDataLoaderCrashReporterMock
+
+- (void)leaveBreadcrumb:(nonnull NSString *)breadcrumb {
+    self.numberOfCallsToLeaveBreadcrumb++;
+}
+
+@end

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
@@ -20,6 +20,7 @@
 @interface SPTDataLoaderServiceSessionSelectorMock ()
 
 @property (nonatomic, strong, readonly) NSURLSession *(^resolve)(SPTDataLoaderRequest *);
+@property (nonatomic, strong) NSURLSession *lastProvidedSession;
 
 @end
 
@@ -39,11 +40,12 @@
 
 - (NSURLSession *)URLSessionForRequest:(SPTDataLoaderRequest *)request
 {
-    return self.resolve(request);
+    _lastProvidedSession = self.resolve(request);
+    return _lastProvidedSession;
 }
 
 - (void)invalidateAndCancel {
-    [self.resolve invalidateAndCancel];
+    [_lastProvidedSession invalidateAndCancel];
 }
 
 @end

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -16,6 +16,7 @@
 
 #import <SPTDataLoader/SPTDataLoaderAuthoriser.h>
 #import <SPTDataLoader/SPTDataLoaderCancellationToken.h>
+#import <SPTDataLoader/SPTDataLoaderCrashReporter.h>
 #import <SPTDataLoader/SPTDataLoaderConsumptionObserver.h>
 #import <SPTDataLoader/SPTDataLoaderDelegate.h>
 #import <SPTDataLoader/SPTDataLoaderExponentialTimer.h>

--- a/include/SPTDataLoader/SPTDataLoaderCrashReporter.h
+++ b/include/SPTDataLoader/SPTDataLoaderCrashReporter.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2015-2023 Spotify AB
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Optional class to be provided to SPTDataLoaderService in order to add more infomation into crash logs.
+@protocol SPTDataLoaderCrashReporter <NSObject>
+
+/// Add a message to the breadcrumbs list.
+- (void)leaveBreadcrumb:(NSString *)breadcrumb;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -21,6 +21,7 @@
 @class SPTDataLoaderResolver;
 @class SPTDataLoaderServerTrustPolicy;
 @protocol SPTDataLoaderAuthoriser;
+@protocol SPTDataLoaderCrashReporter;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -53,6 +54,22 @@ NS_ASSUME_NONNULL_BEGIN
                       customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses;
 
 /**
+ Class constructor
+ @param userAgent The user agent to report as when making HTTP requests
+ @param rateLimiter The limiter for limiting requests per second on a per service basis
+ @param resolver The resolver for rerouting requests to different IP addresses
+ @param customURLProtocolClasses Array of NSURLProtocol Class objects that you want
+                                 to use for this DataLoaderService. May be nil.
+ @param crashReporter The object in which more information (breadcrumbs) will be inflated
+                     so it's easier to debug in case of a crash,
+ */
++ (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
+                                   rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                      resolver:(nullable SPTDataLoaderResolver *)resolver
+                      customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses
+                                 crashReporter:(nullable id<SPTDataLoaderCrashReporter>)crashReporter;
+
+/**
  Convenience class constructor
  @param configuration Custom session configuration
  @param rateLimiter The limiter for limiting requests per second on a per service basis
@@ -61,6 +78,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
                                        rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
                                           resolver:(nullable SPTDataLoaderResolver *)resolver;
+
+/**
+ Convenience class constructor
+ @param configuration Custom session configuration
+ @param rateLimiter The limiter for limiting requests per second on a per service basis
+ @param resolver The resolver for rerouting requests to different IP addresses
+ @param crashReporter The object in which more information (breadcrumbs) will be inflated
+                     so it's easier to debug in case of a crash,
+ */
++ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
+                                       rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                          resolver:(nullable SPTDataLoaderResolver *)resolver
+                                     crashReporter:(nullable id<SPTDataLoaderCrashReporter>)crashReporter;
 
 /**
  Class constructor with QoS
@@ -78,6 +108,24 @@ NS_ASSUME_NONNULL_BEGIN
                               qualityOfService:(NSQualityOfService)qualityOfService __OSX_AVAILABLE(10.10);
 
 /**
+ Class constructor with QoS
+ @param userAgent The user agent to report as when making HTTP requests
+ @param rateLimiter The limiter for limiting requests per second on a per service basis
+ @param resolver The resolver for rerouting requests to different IP addresses
+ @param customURLProtocolClasses Array of NSURLProtocol Class objects that you want
+                                 to use for this DataLoaderService. May be nil.
+ @param qualityOfService The quality of service to use for the URL session queue
+ @param crashReporter The object in which more information (breadcrumbs) will be inflated
+                     so it's easier to debug in case of a crash,
+ */
++ (instancetype)dataLoaderServiceWithUserAgent:(nullable NSString *)userAgent
+                                   rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                      resolver:(nullable SPTDataLoaderResolver *)resolver
+                      customURLProtocolClasses:(nullable NSArray<Class> *)customURLProtocolClasses
+                              qualityOfService:(NSQualityOfService)qualityOfService
+                                 crashReporter:(nullable id<SPTDataLoaderCrashReporter>)crashReporter __OSX_AVAILABLE(10.10);
+
+/**
  Convenience class constructor with QoS
  @param configuration Custom session configuration
  @param rateLimiter The limiter for limiting requests per second on a per service basis
@@ -88,6 +136,21 @@ NS_ASSUME_NONNULL_BEGIN
                                        rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
                                           resolver:(nullable SPTDataLoaderResolver *)resolver
                                   qualityOfService:(NSQualityOfService)qualityOfService __OSX_AVAILABLE(10.10);
+
+/**
+ Convenience class constructor with QoS
+ @param configuration Custom session configuration
+ @param rateLimiter The limiter for limiting requests per second on a per service basis
+ @param resolver The resolver for rerouting requests to different IP addresses
+ @param qualityOfService The quality of service to use for the URL session queue
+ @param crashReporter The object in which more information (breadcrumbs) will be inflated
+                     so it's easier to debug in case of a crash,
+ */
++ (instancetype)dataLoaderServiceWithConfiguration:(NSURLSessionConfiguration *)configuration
+                                       rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                          resolver:(nullable SPTDataLoaderResolver *)resolver
+                                  qualityOfService:(NSQualityOfService)qualityOfService
+                                     crashReporter:(nullable id<SPTDataLoaderCrashReporter>)crashReporter __OSX_AVAILABLE(10.10);
 
 /**
  Creates a data loader factory


### PR DESCRIPTION
### What has changed
- Adds optional `crashReporter` of type `SPTDataLoaderCrashReporter` to constructor

### Why this was changed
This is an attempt to improve crash logging. It takes into account that the app probably has multiple instances of and `SPTDataLoader` during its lifecycle, which is why the breadcrumbs are left only in critical spots:
1. When loads are cancelled
2. When session gets invalidated
3. When there's an attempt to make a request in a invalidated session