### PR TITLE
Add a safeguard on NSURLSession invalidation

### DIFF
--- a/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
@@ -719,6 +719,24 @@
     XCTAssertEqualObjects(handler.task, task);
 }
 
+- (void)testDoNotRecreateTaskWhenTaskIsCancelled
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"https://localhost"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    request.maximumRetryCount = 10;
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+
+    SPTDataLoaderRequestTaskHandler *handler = self.service.handlers.firstObject;
+    NSURLSessionTaskMock *task = [NSURLSessionTaskMock new];
+    handler.task = task;
+
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil];
+    [self.service URLSession:self.session task:task didCompleteWithError:error];
+
+    XCTAssertEqualObjects(handler.task, task);
+}
+
 - (void)testProvidingNewBodyStream
 {
     SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];


### PR DESCRIPTION
On a session invalidation, tasks are usually requested to be cancelled. the `didCompleteWithError` attempts always to create a new task even if the task had been cancelled. That is usally not an issue unless the session has been invalidated. In that case a NSGenericException is raied and the app most likely crashes.