### PR TITLE
Add task handler delegate

### DIFF
--- a/SPTDataLoader.xcodeproj/project.pbxproj
+++ b/SPTDataLoader.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		6994E68C1EE9F72600128CDE /* certs-google.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68B1EE9F49B00128CDE /* certs-google.bundle */; };
 		6994E68D1EE9F72800128CDE /* certs-spotify.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6994E68A1EE9F49B00128CDE /* certs-spotify.bundle */; };
 		EAC45A771C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */; };
+		F504D78C29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = F504D78B29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.m */; };
 		F50DEF6927CEA8910024B526 /* Request+CombineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DEF6827CEA8910024B526 /* Request+CombineTest.swift */; };
 		F50DEF6B27CEA8990024B526 /* Request+ConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DEF6A27CEA8990024B526 /* Request+ConcurrencyTest.swift */; };
 		F50DEF6D27CEA96A0024B526 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DEF6C27CEA96A0024B526 /* TestHelpers.swift */; };
@@ -226,6 +227,8 @@
 		C6515CF41BA2D4C200271211 /* SPTDataLoaderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderDelegate.h; sourceTree = "<group>"; };
 		EAC45A751C0F4633009AA9F9 /* NSURLSessionDataTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLSessionDataTaskMock.h; sourceTree = "<group>"; };
 		EAC45A761C0F4633009AA9F9 /* NSURLSessionDataTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionDataTaskMock.m; sourceTree = "<group>"; };
+		F504D78A29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTDataLoaderRequestTaskHandlerDelegateMock.h; sourceTree = "<group>"; };
+		F504D78B29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTDataLoaderRequestTaskHandlerDelegateMock.m; sourceTree = "<group>"; };
 		F50DEF6827CEA8910024B526 /* Request+CombineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+CombineTest.swift"; sourceTree = "<group>"; };
 		F50DEF6A27CEA8990024B526 /* Request+ConcurrencyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+ConcurrencyTest.swift"; sourceTree = "<group>"; };
 		F50DEF6C27CEA96A0024B526 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
@@ -523,6 +526,8 @@
 				0599409C1A14F32A006D6BE9 /* SPTDataLoaderRequestResponseHandlerDelegateMock.m */,
 				059940411A14BA28006D6BE9 /* SPTDataLoaderRequestResponseHandlerMock.h */,
 				059940421A14BA28006D6BE9 /* SPTDataLoaderRequestResponseHandlerMock.m */,
+				F504D78A29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.h */,
+				F504D78B29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.m */,
 				F7346A2E1CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.h */,
 				F7346A2F1CC2C73600B8AB41 /* SPTDataLoaderServerTrustPolicyMock.m */,
 				2DE3DAC82344E5060022642E /* SPTDataLoaderServiceSessionSelectorMock.h */,
@@ -725,6 +730,7 @@
 				050F53871A2756570094F2BB /* SPTDataLoaderConsumptionObserverMock.m in Sources */,
 				3426C1F424CB2EF900B919B4 /* SPTDataLoaderBlockWrapperTest.m in Sources */,
 				059940A51A14FA65006D6BE9 /* SPTDataLoaderCancellationTokenDelegateMock.m in Sources */,
+				F504D78C29ABCB7500B5CC6B /* SPTDataLoaderRequestTaskHandlerDelegateMock.m in Sources */,
 				059940A21A14F7E1006D6BE9 /* SPTDataLoaderDelegateMock.m in Sources */,
 				0504CB8F1A151B6D00AD54EF /* SPTDataLoaderCancellationTokenImplementationTest.m in Sources */,
 				0504CB8D1A151B0600AD54EF /* SPTDataLoaderCancellationTokenFactoryImplementationTest.m in Sources */,

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -16,12 +16,24 @@
 
 #import <Foundation/Foundation.h>
 
+@class SPTDataLoaderRequestTaskHandler;
 @class SPTDataLoaderRequest;
 @class SPTDataLoaderRateLimiter;
 @class SPTDataLoaderResponse;
+
 @protocol SPTDataLoaderRequestResponseHandler;
 
 NS_ASSUME_NONNULL_BEGIN
+
+@protocol SPTDataLoaderRequestTaskHandlerDelegate <NSObject>
+
+/**
+ Called when the existing task has completed and a new one is required in order to retry the request.
+ @param requestTaskHandler The object handling the request task
+ */
+- (void)requestTaskHandlerNeedsNewTask:(SPTDataLoaderRequestTaskHandler *)requestTaskHandler;
+
+@end
 
 /**
  The handler for performing a URL session task and forwarding the requests to relevant request response handler
@@ -43,15 +55,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Class constructor
+ @param task The task to perform 
  @param request The request object to perform lookup with
- @param task The task to perform
  @param requestResponseHandler The object tie to this operation for potential callbacks
  @param rateLimiter The object controlling the rate limits on a per service basis
+ @param delegate The object listening to the task handler
  */
 + (instancetype)dataLoaderRequestTaskHandlerWithTask:(NSURLSessionTask *)task
                                              request:(SPTDataLoaderRequest *)request
                               requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
-                                         rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter;
+                                         rateLimiter:(nullable SPTDataLoaderRateLimiter *)rateLimiter
+                                            delegate:(id<SPTDataLoaderRequestTaskHandlerDelegate>)delegate;
 
 /**
  Call to tell the operation it has received a response

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.h
@@ -1,0 +1,31 @@
+/*
+ Copyright 2015-2022 Spotify AB
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "SPTDataLoaderRequestTaskHandler.h"
+
+@class NSURLSessionTaskMock;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPTDataLoaderRequestTaskHandlerDelegateMock : NSObject <SPTDataLoaderRequestTaskHandlerDelegate>
+
+@property (nonatomic) NSURLSessionTaskMock *task;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.m
@@ -1,0 +1,41 @@
+/*
+ Copyright 2015-2022 Spotify AB
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "SPTDataLoaderRequestTaskHandlerDelegateMock.h"
+
+#import "NSURLSessionTaskMock.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SPTDataLoaderRequestTaskHandlerDelegateMock
+
+- (NSURLSessionTaskMock *)task
+{
+    if (_task == nil) {
+        _task = [[NSURLSessionTaskMock alloc] init];
+    }
+
+    return _task;
+}
+
+- (void)requestTaskHandlerNeedsNewTask:(SPTDataLoaderRequestTaskHandler *)requestTaskHandler
+{
+    requestTaskHandler.task = self.task;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is an approach for the small improvement I mentioned for https://github.com/spotify/SPTDataLoader/pull/229. The task is currently being reset in all completion scenarios except for cancellation, so this change narrows that behavior to only occur before starting a retry.