### PR TITLE
Prevent a task to be created from an invalid session

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderService.m
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SPTDataLoaderServerTrustPolicy *serverTrustPolicy;
 @property (nonatomic, weak, nullable) NSFileManager *fileManager;
 @property (nonatomic, weak, nullable) Class dataClass;
+@property (nonatomic, assign) BOOL sessionInvalidated;
 
 @end
 
@@ -138,6 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _fileManager = [NSFileManager defaultManager];
         _dataClass = [NSData class];
+        _sessionInvalidated = NO;
     }
 
     return self;
@@ -224,6 +226,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)performRequest:(SPTDataLoaderRequest *)request
 requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseHandler
 {
+    if (self.sessionInvalidated) {
+        [requestResponseHandler cancelledRequest:request];
+        return;
+    }
     if (request.URL == nil || request.cancellationToken.cancelled) {
         return;
     }
@@ -270,6 +276,7 @@ requestResponseHandler:(id<SPTDataLoaderRequestResponseHandler>)requestResponseH
 
 - (void)invalidateAndCancel
 {
+    self.sessionInvalidated = YES;
     [self.sessionSelector invalidateAndCancel];
 }
 

--- a/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
@@ -767,4 +767,14 @@
     XCTAssertEqualObjects(request.URL, URL);
 }
 
+- (void)testCancellingRequestOnSessionInvalidation
+{
+    SPTDataLoaderRequestResponseHandlerMock *requestResponseHandlerMock = [SPTDataLoaderRequestResponseHandlerMock new];
+    NSURL *URL = [NSURL URLWithString:@"https://localhost"];
+    SPTDataLoaderRequest *request = [SPTDataLoaderRequest requestWithURL:URL sourceIdentifier:@""];
+    [self.service invalidateAndCancel];
+    [self.service requestResponseHandler:requestResponseHandlerMock performRequest:request];
+    XCTAssertEqual(requestResponseHandlerMock.numberOfCancelledRequestCalls, 1u);
+}
+
 @end

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
@@ -42,8 +42,8 @@
     return self.resolve(request);
 }
 
-- (void)invalidateAndCancel {
-    [self.resolve invalidateAndCancel];
+- (void)invalidateAndCancel
+{
 }
 
 @end


### PR DESCRIPTION
Authoriser are not cancellable and so after calling `invalidateAndCancel` method on the SPTDataLoaderService some in-flight request still going through authoriser might end up to create a URLSessionTask on an already invalidated one with the result of a throwing exception