### PR TITLE
Fix: Do Not Retry on 404 HTTP Status Code

### DIFF
--- a/Sources/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResponse.m
@@ -106,8 +106,8 @@ static NSString * const SPTDataLoaderResponseHeaderRetryAfter = @"Retry-After";
             case SPTDataLoaderResponseHTTPStatusCodeExpectationFail:
             case SPTDataLoaderResponseHTTPStatusCodeHTTPVersionNotSupported:
             case SPTDataLoaderResponseHTTPStatusCodeNotImplemented:
-                return NO;
             case SPTDataLoaderResponseHTTPStatusCodeNotFound:
+                return NO;
             case SPTDataLoaderResponseHTTPStatusCodeRequestTimeout:
             case SPTDataLoaderResponseHTTPStatusCodeUnsupportedMediaTypes:
             case SPTDataLoaderResponseHTTPStatusCodeInternalServerError:

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -125,7 +125,7 @@
     [self.handler receiveResponse:httpResponse];
     [self.handler completeWithError:nil];
     XCTAssertEqual(self.requestResponseHandler.numberOfSuccessfulDataResponseCalls, 0u, @"The handler did relay a successful response onto its request response handler when it should have silently retried");
-    XCTAssertEqual(self.requestResponseHandler.numberOfFailedResponseCalls, 0u, @"The handler did relay a failed response onto its request response handler when it should have silently retried");
+    XCTAssertEqual(self.requestResponseHandler.numberOfFailedResponseCalls, 1u, @"The handler did not relay a failed response onto its request response handler for a 404 status code");
 }
 
 - (void)testRetryWithResponseBody

--- a/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
@@ -69,7 +69,7 @@
                                                  headerFields:nil];
     self.response = [SPTDataLoaderResponse dataLoaderResponseWithRequest:self.request response:self.urlResponse];
     BOOL shouldRetry = [self.response shouldRetry];
-    XCTAssertTrue(shouldRetry, @"The response should retry when given the HTTP status code of Not Found");
+    XCTAssertFalse(shouldRetry, @"The response should not retry when given the HTTP status code of Not Found");
 }
 
 - (void)testShouldRetryForCertificateRejection


### PR DESCRIPTION
Updated the retry logic in `SPTDataLoader` to exclude 404 Not Found from retryable HTTP status codes. Previously, 404 responses were retried by default, which could lead to unnecessary network requests and delays. 