### PR TITLE
Simplify copyright notice

### DIFF
--- a/Framework/SPTDataLoader.h
+++ b/Framework/SPTDataLoader.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderAuthoriser.h>

--- a/Sources/SPTDataLoader/NSDictionary+HeaderSize.h
+++ b/Sources/SPTDataLoader/NSDictionary+HeaderSize.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/NSDictionary+HeaderSize.m
+++ b/Sources/SPTDataLoader/NSDictionary+HeaderSize.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSDictionary+HeaderSize.h"

--- a/Sources/SPTDataLoader/SPTDataLoader.m
+++ b/Sources/SPTDataLoader/SPTDataLoader.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderImplementation+Private.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderBlockWrapper.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderBlockWrapper.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoader.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactory.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementation.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderCancellationTokenFactoryImplementation.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderCancellationTokenImplementation.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderCancellationTokenImplementation.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderExponentialTimer.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderExponentialTimer.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderExponentialTimer.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderFactory+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderFactory+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderFactory.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderFactory.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderFactory.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderFactory.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderImplementation+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderImplementation+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderImplementation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRateLimiter+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRateLimiter+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderRateLimiter.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRateLimiter.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRateLimiter.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderRateLimiter.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRequest+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequest+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderRequest.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRequest.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderRequest.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestResponseHandler.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderRequestTaskHandler.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderRequestTaskHandler.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderResolver.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolver.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderResolver.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResolverAddress.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderResolverAddress.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderResponse+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderResponse+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderResponse.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderResponse.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderResponse.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderResponse.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderServerTrustPolicy.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderServerTrustPolicy.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderServerTrustPolicy.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderService+Private.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderService+Private.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderService.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderService.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderService.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderService+Private.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderServiceSessionSelector.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderServiceSessionSelector.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProvider.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProvider.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.h
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderTimeProvider.h"

--- a/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.m
+++ b/Sources/SPTDataLoader/SPTDataLoaderTimeProviderImplementation.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderTimeProviderImplementation.h"

--- a/Sources/SPTDataLoaderSwift/DataLoader.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoader.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/DataLoaderError.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderError.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 /// An error that occurs during request execution.
 public enum RequestError: Error {

--- a/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
+++ b/Sources/SPTDataLoaderSwift/DataLoaderWrapper.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/Request+Combine.swift
+++ b/Sources/SPTDataLoaderSwift/Request+Combine.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 #if canImport(Combine)
 

--- a/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
+++ b/Sources/SPTDataLoaderSwift/Request+Concurrency.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 

--- a/Sources/SPTDataLoaderSwift/Request.swift
+++ b/Sources/SPTDataLoaderSwift/Request.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/Response.swift
+++ b/Sources/SPTDataLoaderSwift/Response.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/ResponseDecoder.swift
+++ b/Sources/SPTDataLoaderSwift/ResponseDecoder.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
+++ b/Sources/SPTDataLoaderSwift/ResponseSerializer.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/SPTDataLoader.swift
+++ b/Sources/SPTDataLoaderSwift/SPTDataLoader.swift
@@ -1,15 +1,4 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @_exported import SPTDataLoader

--- a/Sources/SPTDataLoaderSwift/Utilities/AccessLock.swift
+++ b/Sources/SPTDataLoaderSwift/Utilities/AccessLock.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 

--- a/Sources/SPTDataLoaderSwift/Utilities/Result+Convenience.swift
+++ b/Sources/SPTDataLoaderSwift/Utilities/Result+Convenience.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 extension Result {
     var success: Success? {

--- a/Tests/SPTDataLoader/NSDictionaryHeaderSizeTest.m
+++ b/Tests/SPTDataLoader/NSDictionaryHeaderSizeTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderBlockWrapperTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderBlockWrapperTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenFactoryImplementationTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderCancellationTokenImplementationTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderExponentialTimerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderExponentialTimerTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderFactoryTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderFactoryTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderRateLimiterTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRateLimiterTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTaskHandlerTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderRequestTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderResolverAddressTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResolverAddressTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderResolverTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResolverTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderResponseTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderServerTrustPolicyTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServerTrustPolicyTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderServiceTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/SPTDataLoaderTimeProviderImplementationTest.m
+++ b/Tests/SPTDataLoader/SPTDataLoaderTimeProviderImplementationTest.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <XCTest/XCTest.h>

--- a/Tests/SPTDataLoader/Utilities/NSBundleMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSBundleMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSBundleMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSBundleMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSBundleMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSDataMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSDataMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSDataMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSDataMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSDataMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSFileManagerMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSFileManagerMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSFileManagerMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSFileManagerMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSFileManagerMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLAuthenticationChallengeMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSURLAuthenticationChallengeMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDataTaskMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSURLSessionDataTaskMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionDownloadTaskMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSURLSessionDownloadTaskMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSURLSessionMock.h"

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.h
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.m
+++ b/Tests/SPTDataLoader/Utilities/NSURLSessionTaskMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSURLSessionTaskMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderAuthoriserMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderAuthoriserMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenDelegateMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderCancellationTokenDelegateMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderCancellationTokenFactoryMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderCancellationTokenFactoryMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderConsumptionObserverMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderConsumptionObserverMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderDelegateMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderDelegateMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerDelegateMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderRequestResponseHandlerDelegateMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestResponseHandlerMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderRequestResponseHandlerMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderRequestTaskHandlerDelegateMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderRequestTaskHandlerDelegateMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderServerTrustPolicy.h>

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServerTrustPolicyMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderServerTrustPolicyMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderServiceSessionSelector.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderServiceSessionSelectorMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderServiceSessionSelectorMock.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.h
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderTimeProvider.h"

--- a/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.m
+++ b/Tests/SPTDataLoader/Utilities/SPTDataLoaderTimeProviderMock.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderTimeProviderMock.h"

--- a/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataLoaderWrapperTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DataResponseSerializerTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/DecodableResponseSerializerTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
+++ b/Tests/SPTDataLoaderSwift/JSONResponseSerializerTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/Request+CombineTest.swift
+++ b/Tests/SPTDataLoaderSwift/Request+CombineTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 #if canImport(Combine)
 

--- a/Tests/SPTDataLoaderSwift/Request+ConcurrencyTest.swift
+++ b/Tests/SPTDataLoaderSwift/Request+ConcurrencyTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 

--- a/Tests/SPTDataLoaderSwift/RequestTest.swift
+++ b/Tests/SPTDataLoaderSwift/RequestTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/ResponseTest.swift
+++ b/Tests/SPTDataLoaderSwift/ResponseTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/SPTDataLoaderFactoryConvenienceTest.swift
+++ b/Tests/SPTDataLoaderSwift/SPTDataLoaderFactoryConvenienceTest.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 @testable import SPTDataLoaderSwift
 

--- a/Tests/SPTDataLoaderSwift/Utilities/CancellationTokenFake.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/CancellationTokenFake.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import SPTDataLoader
 

--- a/Tests/SPTDataLoaderSwift/Utilities/DataLoaderResponseFake.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/DataLoaderResponseFake.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import SPTDataLoader
 

--- a/Tests/SPTDataLoaderSwift/Utilities/StubbedNetwork.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/StubbedNetwork.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import SPTDataLoader
 

--- a/Tests/SPTDataLoaderSwift/Utilities/TestHelpers.swift
+++ b/Tests/SPTDataLoaderSwift/Utilities/TestHelpers.swift
@@ -1,16 +1,5 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import SPTDataLoaderSwift
 

--- a/ci/expected_license_header.txt
+++ b/ci/expected_license_header.txt
@@ -1,15 +1,4 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */

--- a/ci/expected_license_header_swift.txt
+++ b/ci/expected_license_header_swift.txt
@@ -1,13 +1,2 @@
-// Copyright 2015-2023 Spotify AB
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0

--- a/ci/validate_license_conformance.sh
+++ b/ci/validate_license_conformance.sh
@@ -1,22 +1,4 @@
 #!/usr/bin/env bash
-# Copyright (c) 2015-2021 Spotify AB.
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 
 set -uo pipefail
 

--- a/demo/AppDelegate.h
+++ b/demo/AppDelegate.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <UIKit/UIKit.h>

--- a/demo/AppDelegate.m
+++ b/demo/AppDelegate.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "AppDelegate.h"

--- a/demo/ClientKeys.h
+++ b/demo/ClientKeys.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/demo/NSString+OAuthBlob.h
+++ b/demo/NSString+OAuthBlob.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/demo/NSString+OAuthBlob.m
+++ b/demo/NSString+OAuthBlob.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "NSString+OAuthBlob.h"

--- a/demo/PlaylistsViewController.h
+++ b/demo/PlaylistsViewController.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <UIKit/UIKit.h>

--- a/demo/PlaylistsViewController.m
+++ b/demo/PlaylistsViewController.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "PlaylistsViewController.h"

--- a/demo/PlaylistsViewModel.h
+++ b/demo/PlaylistsViewModel.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/demo/PlaylistsViewModel.m
+++ b/demo/PlaylistsViewModel.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "PlaylistsViewModel.h"

--- a/demo/SPTDataLoaderAuthoriserOAuth.h
+++ b/demo/SPTDataLoaderAuthoriserOAuth.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/demo/SPTDataLoaderAuthoriserOAuth.m
+++ b/demo/SPTDataLoaderAuthoriserOAuth.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "SPTDataLoaderAuthoriserOAuth.h"

--- a/demo/ViewController.h
+++ b/demo/ViewController.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <UIKit/UIKit.h>

--- a/demo/ViewController.m
+++ b/demo/ViewController.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import "ViewController.h"

--- a/demo/main.m
+++ b/demo/main.m
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <UIKit/UIKit.h>

--- a/include/SPTDataLoader/SPTDataLoader.h
+++ b/include/SPTDataLoader/SPTDataLoader.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <SPTDataLoader/SPTDataLoaderAuthoriser.h>

--- a/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
+++ b/include/SPTDataLoader/SPTDataLoaderAuthoriser.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
+++ b/include/SPTDataLoader/SPTDataLoaderBlockWrapper.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
+++ b/include/SPTDataLoader/SPTDataLoaderCancellationToken.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
+++ b/include/SPTDataLoader/SPTDataLoaderConsumptionObserver.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderDelegate.h
+++ b/include/SPTDataLoader/SPTDataLoaderDelegate.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
+++ b/include/SPTDataLoader/SPTDataLoaderExponentialTimer.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderFactory.h
+++ b/include/SPTDataLoader/SPTDataLoaderFactory.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderImplementation.h
+++ b/include/SPTDataLoader/SPTDataLoaderImplementation.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
+++ b/include/SPTDataLoader/SPTDataLoaderRateLimiter.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderRequest.h
+++ b/include/SPTDataLoader/SPTDataLoaderRequest.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderResolver.h
+++ b/include/SPTDataLoader/SPTDataLoaderResolver.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderResponse.h
+++ b/include/SPTDataLoader/SPTDataLoaderResponse.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderServerTrustPolicy.h
+++ b/include/SPTDataLoader/SPTDataLoaderServerTrustPolicy.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>

--- a/include/SPTDataLoader/SPTDataLoaderService.h
+++ b/include/SPTDataLoader/SPTDataLoaderService.h
@@ -1,17 +1,6 @@
 /*
- Copyright 2015-2023 Spotify AB
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Copyright Spotify AB.
+ SPDX-License-Identifier: Apache-2.0
  */
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
Maintaining a date range is not strictly necessary and it was sometimes updated without any significant changes being made to the code.¹ Excess license boilerplate can be removed by adopting the recommended short variant.²

¹ https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects
² https://www.apache.org/foundation/license-faq.html#Apply-My-Software